### PR TITLE
Added File() baseline and AsyncFile sanity check to the latency benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,4 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+BDN.Auto/

--- a/Bench.ps1
+++ b/Bench.ps1
@@ -1,0 +1,18 @@
+echo "bench: Benchmarking started"
+
+Push-Location $PSScriptRoot
+
+& dotnet restore --no-cache
+
+foreach ($test in ls test/*.PerformanceTests) {
+    Push-Location $test
+
+	echo "bench: Benchmarking project in $test"
+
+    & dotnet test -c Release --framework net4.5.2
+    if($LASTEXITCODE -ne 0) { exit 3 }
+
+    Pop-Location
+}
+
+Pop-Location

--- a/serilog-sinks-async.sln
+++ b/serilog-sinks-async.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "global", "global", "{154C7C14-E737-40DF-A631-B1673FE76187}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
+		Bench.ps1 = Bench.ps1
 		Build.ps1 = Build.ps1
 		global.json = global.json
 		LICENSE = LICENSE

--- a/test/Serilog.Sinks.Async.PerformanceTests/LatencyBenchmark.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/LatencyBenchmark.cs
@@ -1,52 +1,78 @@
 ﻿using System;
+using System.IO;
 using BenchmarkDotNet.Attributes;
-using Serilog;
 using Serilog.Core;
+using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Parsing;
+using Serilog.Sinks.Async.PerformanceTests.Support;
 
 namespace Serilog.Sinks.Async.PerformanceTests
 {
     public class LatencyBenchmark
     {
-        private const int Count = 10000;
-
         private readonly LogEvent _evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
             new MessageTemplate(new[] {new TextToken("Hello")}), new LogEventProperty[0]);
 
-        private Logger _syncLogger, _asyncLogger;
+        private Logger _syncLogger, _asyncLogger, _fileLogger, _asyncFileLogger;
+
+        static LatencyBenchmark()
+        {
+            SelfLog.Enable(new TerminatingTextWriter());
+        }
 
         [Setup]
         public void Reset()
         {
-            _syncLogger?.Dispose();
-            _asyncLogger?.Dispose();
+            foreach (var logger in new[] { _syncLogger, _asyncLogger, _fileLogger, _asyncFileLogger})
+            {
+                logger?.Dispose();
+            }
+
+            foreach (var tmp in Directory.GetFiles(".", "*.tmplog"))
+            {
+                System.IO.File.Delete(tmp);
+            }
 
             _syncLogger = new LoggerConfiguration()
                 .WriteTo.Sink(new SilentSink())
                 .CreateLogger();
 
             _asyncLogger = new LoggerConfiguration()
-                .WriteTo.Async(a => a.Sink(new SilentSink()))
+                .WriteTo.Async(a => a.Sink(new SilentSink()), 10000000)
+                .CreateLogger();
+
+            _fileLogger = new LoggerConfiguration()
+                .WriteTo.File("sync-file.tmplog")
+                .CreateLogger();
+
+            _asyncFileLogger = new LoggerConfiguration()
+                .WriteTo.Async(a => a.File("async-file.tmplog"), 10000000)
                 .CreateLogger();
         }
 
         [Benchmark(Baseline = true)]
         public void Sync()
         {
-            for (var i = 0; i < Count; ++i)
-            {
-                _syncLogger.Write(_evt);
-            }
+            _syncLogger.Write(_evt);
         }
 
         [Benchmark]
         public void Async()
         {
-            for (var i = 0; i < Count; ++i)
-            {
-                _asyncLogger.Write(_evt);
-            }
+            _asyncLogger.Write(_evt);
+        }
+
+        [Benchmark]
+        public void File()
+        {
+            _fileLogger.Write(_evt);
+        }
+
+        [Benchmark]
+        public void AsyncFile()
+        {
+            _asyncFileLogger.Write(_evt);
         }
     }
 }

--- a/test/Serilog.Sinks.Async.PerformanceTests/Support/TerminatingTextWriter.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/Support/TerminatingTextWriter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace Serilog.Sinks.Async.PerformanceTests.Support
+{
+    public class TerminatingTextWriter : TextWriter
+    {
+        public override Encoding Encoding { get; } = Encoding.ASCII;
+
+        public override void Write(char value)
+        {
+            Console.WriteLine("SelfLog triggered");
+            Environment.Exit(1);
+        }
+    }
+}

--- a/test/Serilog.Sinks.Async.PerformanceTests/project.json
+++ b/test/Serilog.Sinks.Async.PerformanceTests/project.json
@@ -3,6 +3,7 @@
 
   "dependencies": {
     "Serilog.Sinks.Async": { "target": "project" },
+    "Serilog.Sinks.File": "2.2.0",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-build10025",
     "BenchmarkDotNet": "0.9.7-beta"
@@ -18,8 +19,7 @@
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0"
-        },
-        "System.Collections": "4.0.11"
+        }
       },
       "imports": [
         "dnxcore50",


### PR DESCRIPTION
Getting the following results:

```ini

BenchmarkDotNet=v0.9.7.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-3720QM CPU 2.60GHz, ProcessorCount=8
Frequency=2533308 ticks, Resolution=394.7408 ns, Timer=TSC
HostCLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
JitModules=clrjit-v4.6.1080.0

Type=LatencyBenchmark  Mode=Throughput  

```
    Method |         Median |      StdDev | Scaled |
---------- |--------------- |------------ |------- |
      Sync |     50.2585 ns |   0.7480 ns |   1.00 |
     Async |    440.9520 ns |  20.1586 ns |   8.77 |
      File | 10,527.3446 ns | 171.1528 ns | 209.46 |
 AsyncFile |    209.3905 ns |   5.7984 ns |   4.17 |


This required some messing about as the original benchmarks were overflowing the buffer, and thus were benchmarking fail-plus-SelfLog latency rather than the enqueueing latency.

I think the difference between Async and AsyncFile can be put down to contention: the worker thread that's writing the events to the log file won't be interacting with the `BlockingCollection` as much.

50x lower-latency file logging (on SSD) is pretty cool; I'm sure we can improve but it's a decent result :-)

