### PR TITLE
remove System.Threading.Thread dependency

### DIFF
--- a/src/Serilog.Sinks.Async/project.json
+++ b/src/Serilog.Sinks.Async/project.json
@@ -24,16 +24,9 @@
   "frameworks": {
     "net4.5": {
     },
-    "netstandard1.3": {
+    "netstandard1.1": {
       "dependencies": {
-        "Microsoft.CSharp": "4.0.1",
-        "System.Collections": "4.0.11",
-        "System.Linq": "4.1.0",
-        "System.Runtime": "4.1.0",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Threading": "4.0.11",
-        "System.Collections.Concurrent": "4.0.12",
-        "System.Threading.Thread": "4.0.0"
+        "System.Collections.Concurrent": "4.0.12"
       }
     }
   }


### PR DESCRIPTION
- replaces `Thread` to `Task`
- adds support for older platforms up to `netstandard1.1`

One behavior change: there is no `Name` being set for the background thread. While debugging you can track this thread via `Tasks` window in the `VS` under `Pump` name.

Related to [this](https://github.com/serilog/serilog-sinks-seq/issues/40) `UWP` issue.