### PR TITLE
Fulfills #20 - add option to block when the queue is full, instead of dropping events

### DIFF
--- a/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
+++ b/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.ComponentModel;
 using Serilog.Configuration;
-
 using Serilog.Sinks.Async;
 
 namespace Serilog
@@ -10,6 +10,24 @@ namespace Serilog
     /// </summary>
     public static class LoggerConfigurationAsyncExtensions
     {
+        /// <summary>
+        /// Configure a sink to be invoked asynchronously, on a background worker thread.
+        /// </summary>
+        /// <param name="loggerSinkConfiguration">The <see cref="LoggerSinkConfiguration"/> being configured.</param>
+        /// <param name="configure">An action that configures the wrapped sink.</param>
+        /// <param name="bufferSize">The size of the concurrent queue used to feed the background worker thread. If
+        /// the thread is unable to process events quickly enough and the queue is filled, subsequent events will be 
+        /// dropped until room is made in the queue.</param>
+        /// <returns>A <see cref="LoggerConfiguration"/> allowing configuration to continue.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static LoggerConfiguration Async(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            Action<LoggerSinkConfiguration> configure,
+            int bufferSize)
+        {
+            return loggerSinkConfiguration.Async(configure, bufferSize, false);
+        }
+
         /// <summary>
         /// Configure a sink to be invoked asynchronously, on a background worker thread.
         /// </summary>
@@ -32,5 +50,6 @@ namespace Serilog
                 wrappedSink => new BackgroundWorkerSink(wrappedSink, bufferSize, blockWhenFull),
                 configure);
         }
+
     }
 }

--- a/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
+++ b/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
@@ -16,17 +16,20 @@ namespace Serilog
         /// <param name="loggerSinkConfiguration">The <see cref="LoggerSinkConfiguration"/> being configured.</param>
         /// <param name="configure">An action that configures the wrapped sink.</param>
         /// <param name="bufferSize">The size of the concurrent queue used to feed the background worker thread. If
-        /// the thread is unable to process events quickly enough and the queue is filled, subsequent events will be
-        /// dropped until room is made in the queue.</param>
+        /// the thread is unable to process events quickly enough and the queue is filled, depending on 
+        /// <paramref name="blockWhenFull"/> the queue will block or subsequent events will be dropped until 
+        /// room is made in the queue.</param>
+        /// <param name="blockWhenFull">Block when the queue is full, instead of dropping events.</param>
         /// <returns>A <see cref="LoggerConfiguration"/> allowing configuration to continue.</returns>
         public static LoggerConfiguration Async(
             this LoggerSinkConfiguration loggerSinkConfiguration,
             Action<LoggerSinkConfiguration> configure,
-            int bufferSize = 10000)
+            int bufferSize = 10000,
+            bool blockWhenFull = false)
         {
             return LoggerSinkConfiguration.Wrap(
                 loggerSinkConfiguration,
-                wrappedSink => new BackgroundWorkerSink(wrappedSink, bufferSize),
+                wrappedSink => new BackgroundWorkerSink(wrappedSink, bufferSize, blockWhenFull),
                 configure);
         }
     }

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
@@ -11,22 +11,15 @@ using Xunit;
 
 namespace Serilog.Sinks.Async.Tests
 {
-    public class BackgroundWorkerSinkSpec : IDisposable
+    public class BackgroundWorkerSinkSpec
     {
         readonly Logger _logger;
         readonly MemorySink _innerSink;
-        BackgroundWorkerSink _sink;
 
         public BackgroundWorkerSinkSpec()
         {
             _innerSink = new MemorySink();
             _logger = new LoggerConfiguration().WriteTo.Sink(_innerSink).CreateLogger();
-            _sink = new BackgroundWorkerSink(_logger, 10000, false);
-        }
-
-        public void Dispose()
-        {
-            _sink.Dispose();
         }
 
         [Fact]
@@ -38,118 +31,134 @@ namespace Serilog.Sinks.Async.Tests
         [Fact]
         public async Task WhenEmitSingle_ThenRelaysToInnerSink()
         {
-            var logEvent = CreateEvent();
-            _sink.Emit(logEvent);
+            using (var sink = this.CreateSinkWithDefaultOptions())
+            {
+                var logEvent = CreateEvent();
 
-            await Task.Delay(TimeSpan.FromSeconds(3));
+                sink.Emit(logEvent);
 
-            Assert.Equal(1, _innerSink.Events.Count);
+                await Task.Delay(TimeSpan.FromSeconds(3));
+
+                Assert.Equal(1, _innerSink.Events.Count);
+            }
         }
 
         [Fact]
         public async Task WhenInnerEmitThrows_ThenContinuesRelaysToInnerSink()
         {
-            _innerSink.ThrowAfterCollecting = true;
-
-            var events = new List<LogEvent>
+            using (var sink = this.CreateSinkWithDefaultOptions())
             {
-                CreateEvent(),
-                CreateEvent(),
-                CreateEvent()
-            };
-            events.ForEach(e => _sink.Emit(e));
+                _innerSink.ThrowAfterCollecting = true;
 
-            await Task.Delay(TimeSpan.FromSeconds(3));
+                var events = new List<LogEvent>
+                {
+                    CreateEvent(),
+                    CreateEvent(),
+                    CreateEvent()
+                };
+                events.ForEach(e => sink.Emit(e));
 
-            Assert.Equal(3, _innerSink.Events.Count);
+                await Task.Delay(TimeSpan.FromSeconds(3));
+
+                Assert.Equal(3, _innerSink.Events.Count);
+            }
         }
 
         [Fact]
         public async Task WhenEmitMultipleTimes_ThenRelaysToInnerSink()
         {
-            var events = new List<LogEvent>
+            using (var sink = this.CreateSinkWithDefaultOptions())
             {
-                CreateEvent(),
-                CreateEvent(),
-                CreateEvent()
-            };
+                var events = new List<LogEvent>
+                {
+                    CreateEvent(),
+                    CreateEvent(),
+                    CreateEvent()
+                };
+                events.ForEach(e => { sink.Emit(e); });
 
-            events.ForEach(e => { _sink.Emit(e); });
+                await Task.Delay(TimeSpan.FromSeconds(3));
 
-            await Task.Delay(TimeSpan.FromSeconds(3));
-
-            Assert.Equal(3, _innerSink.Events.Count);
+                Assert.Equal(3, _innerSink.Events.Count);
+            }
         }
 
         [Fact]
         public async Task WhenQueueFull_ThenDropsEvents()
         {
-            _sink = new BackgroundWorkerSink(_logger, 1, false);
-
-            // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity 
-            // after the first event is popped
-            _innerSink.DelayEmit = TimeSpan.FromMilliseconds(300);
-
-            var events = new List<LogEvent>
+            using (var sink = new BackgroundWorkerSink(_logger, 1, false))
             {
-                CreateEvent(),
-                CreateEvent(),
-                CreateEvent(),
-                CreateEvent(),
-                CreateEvent()
-            };
-            events.ForEach(e =>
-            {
-                var sw = Stopwatch.StartNew();
-                _sink.Emit(e);
-                sw.Stop();
+                // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity 
+                // after the first event is popped
+                _innerSink.DelayEmit = TimeSpan.FromMilliseconds(300);
 
-                Assert.True(sw.ElapsedMilliseconds < 200, "Should not block the caller when the queue is full");
-            });
+                var events = new List<LogEvent>
+                {
+                    CreateEvent(),
+                    CreateEvent(),
+                    CreateEvent(),
+                    CreateEvent(),
+                    CreateEvent()
+                };
+                events.ForEach(e =>
+                {
+                    var sw = Stopwatch.StartNew();
+                    sink.Emit(e);
+                    sw.Stop();
 
-            // If we *weren't* dropped events, the delay in the inner sink would mean the 5 events would take 
-            // at least 15 seconds to process
-            await Task.Delay(TimeSpan.FromSeconds(2));
+                    Assert.True(sw.ElapsedMilliseconds < 200, "Should not block the caller when the queue is full");
+                });
 
-            // Events should be dropped
-            Assert.Equal(2, _innerSink.Events.Count);
+                // If we *weren't* dropped events, the delay in the inner sink would mean the 5 events would take 
+                // at least 15 seconds to process
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
+                // Events should be dropped
+                Assert.Equal(2, _innerSink.Events.Count);
+            }
         }
 
         [Fact]
         public async Task WhenQueueFull_ThenBlocks()
         {
-            _sink = new BackgroundWorkerSink(_logger, 1, true);
-
-            // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity 
-            // after the first event is popped
-            _innerSink.DelayEmit = TimeSpan.FromMilliseconds(300);
-
-            var events = new List<LogEvent>
+            using (var sink = new BackgroundWorkerSink(_logger, 1, true))
             {
-                CreateEvent(),
-                CreateEvent(),
-                CreateEvent()
-            };
+                // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity 
+                // after the first event is popped
+                _innerSink.DelayEmit = TimeSpan.FromMilliseconds(300);
 
-            int i = 0;
-            events.ForEach(e =>
-            {
-                var sw = Stopwatch.StartNew();
-                _sink.Emit(e);
-                sw.Stop();
-
-                // Emit should return immediately the first time, since the queue is not yet full. On 
-                // subsequent calls, the queue should be full, so we should be blocked
-                if (i > 0)
+                var events = new List<LogEvent>
                 {
-                    Assert.True(sw.ElapsedMilliseconds > 200, "Should block the caller when the queue is full");
-                }
-            });
+                    CreateEvent(),
+                    CreateEvent(),
+                    CreateEvent()
+                };
 
-            await Task.Delay(TimeSpan.FromSeconds(2));
+                int i = 0;
+                events.ForEach(e =>
+                {
+                    var sw = Stopwatch.StartNew();
+                    sink.Emit(e);
+                    sw.Stop();
 
-            // No events should be dropped
-            Assert.Equal(3, _innerSink.Events.Count);
+                    // Emit should return immediately the first time, since the queue is not yet full. On 
+                    // subsequent calls, the queue should be full, so we should be blocked
+                    if (i > 0)
+                    {
+                        Assert.True(sw.ElapsedMilliseconds > 200, "Should block the caller when the queue is full");
+                    }
+                });
+
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
+                // No events should be dropped
+                Assert.Equal(3, _innerSink.Events.Count);
+            }
+        }
+
+        private BackgroundWorkerSink CreateSinkWithDefaultOptions()
+        {
+            return new BackgroundWorkerSink(_logger, 10000, false);
         }
 
         private static LogEvent CreateEvent()

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Serilog.Core;
+using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Parsing;
-using Serilog.Sinks.Async.Tests;
 using Serilog.Sinks.Async.Tests.Support;
 using Xunit;
 
@@ -13,14 +14,15 @@ namespace Serilog.Sinks.Async.Tests
 {
     public class BackgroundWorkerSinkSpec : IDisposable
     {
+        readonly Logger _logger;
         readonly MemorySink _innerSink;
-        readonly BackgroundWorkerSink _sink;
+        BackgroundWorkerSink _sink;
 
         public BackgroundWorkerSinkSpec()
         {
             _innerSink = new MemorySink();
-            var logger = new LoggerConfiguration().WriteTo.Sink(_innerSink).CreateLogger();
-            _sink = new BackgroundWorkerSink(logger, 10000);
+            _logger = new LoggerConfiguration().WriteTo.Sink(_innerSink).CreateLogger();
+            _sink = new BackgroundWorkerSink(_logger, 10000, false);
         }
 
         public void Dispose()
@@ -31,7 +33,7 @@ namespace Serilog.Sinks.Async.Tests
         [Fact]
         public void WhenCtorWithNullSink_ThenThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => new BackgroundWorkerSink(null, 10000));
+            Assert.Throws<ArgumentNullException>(() => new BackgroundWorkerSink(null, 10000, false));
         }
 
         [Fact]
@@ -39,6 +41,7 @@ namespace Serilog.Sinks.Async.Tests
         {
             var logEvent = CreateEvent();
             _sink.Emit(logEvent);
+            _sink.Dispose();
 
             await Task.Delay(TimeSpan.FromSeconds(3));
 
@@ -77,6 +80,77 @@ namespace Serilog.Sinks.Async.Tests
 
             await Task.Delay(TimeSpan.FromSeconds(3));
 
+            Assert.Equal(3, _innerSink.Events.Count);
+        }
+
+        [Fact]
+        public async Task WhenQueueFull_ThenDropsEvents()
+        {
+            _sink = new BackgroundWorkerSink(_logger, 1, false);
+
+            // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity 
+            // after the first event is popped
+            _innerSink.DelayEmit = true;
+
+            var events = new List<LogEvent>
+            {
+                CreateEvent(),
+                CreateEvent(),
+                CreateEvent(),
+                CreateEvent(),
+                CreateEvent()
+            };
+            events.ForEach(e =>
+            {
+                var sw = Stopwatch.StartNew();
+                _sink.Emit(e);
+                sw.Stop();
+
+                Assert.True(sw.ElapsedMilliseconds < 2000, "Should not block the caller when the queue is full");
+            });
+
+            // If we *weren't* dropped events, the delay in the inner sink would mean the 5 events would take 
+            // at least 15 seconds to process
+            await Task.Delay(TimeSpan.FromSeconds(18));
+
+            // Events should be dropped
+            Assert.Equal(2, _innerSink.Events.Count);
+        }
+
+        [Fact]
+        public async Task WhenQueueFull_ThenBlocks()
+        {
+            _sink = new BackgroundWorkerSink(_logger, 1, true);
+
+            // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity 
+            // after the first event is popped
+            _innerSink.DelayEmit = true;
+
+            var events = new List<LogEvent>
+            {
+                CreateEvent(),
+                CreateEvent(),
+                CreateEvent()
+            };
+
+            int i = 0;
+            events.ForEach(e =>
+            {
+                var sw = Stopwatch.StartNew();
+                _sink.Emit(e);
+                sw.Stop();
+
+                // Emit should return immediately the first time, since the queue is not yet full. On 
+                // subsequent calls, the queue should be full, so we should be blocked
+                if (i > 0)
+                {
+                    Assert.True(sw.ElapsedMilliseconds > 2000, "Should block the caller when the queue is full");
+                }
+            });
+
+            await Task.Delay(TimeSpan.FromSeconds(12));
+
+            // No events should be dropped
             Assert.Equal(3, _innerSink.Events.Count);
         }
 

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkTests.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading;
-using Serilog.Core;
-using Serilog.Events;
-using Serilog.Parsing;
-using Serilog.Sinks.Async.Tests.Support;
+﻿using Serilog.Sinks.Async.Tests.Support;
 using Xunit;
 
 namespace Serilog.Sinks.Async.Tests

--- a/test/Serilog.Sinks.Async.Tests/Support/MemorySink.cs
+++ b/test/Serilog.Sinks.Async.Tests/Support/MemorySink.cs
@@ -10,12 +10,12 @@ namespace Serilog.Sinks.Async.Tests.Support
     {
         public ConcurrentBag<LogEvent> Events { get; } = new ConcurrentBag<LogEvent>();
         public bool ThrowAfterCollecting { get; set; }
-        public bool DelayEmit { get; set; }
+        public TimeSpan? DelayEmit { get; set; }
 
         public void Emit(LogEvent logEvent)
         {
-            if (DelayEmit)
-                Task.Delay(TimeSpan.FromSeconds(3)).Wait();
+            if (DelayEmit.HasValue)
+                Task.Delay(DelayEmit.Value).Wait();
 
             Events.Add(logEvent);
 

--- a/test/Serilog.Sinks.Async.Tests/Support/MemorySink.cs
+++ b/test/Serilog.Sinks.Async.Tests/Support/MemorySink.cs
@@ -2,6 +2,7 @@
 using Serilog.Core;
 using System.Collections.Concurrent;
 using System;
+using System.Threading.Tasks;
 
 namespace Serilog.Sinks.Async.Tests.Support
 {
@@ -9,9 +10,13 @@ namespace Serilog.Sinks.Async.Tests.Support
     {
         public ConcurrentBag<LogEvent> Events { get; } = new ConcurrentBag<LogEvent>();
         public bool ThrowAfterCollecting { get; set; }
+        public bool DelayEmit { get; set; }
 
         public void Emit(LogEvent logEvent)
         {
+            if (DelayEmit)
+                Task.Delay(TimeSpan.FromSeconds(3)).Wait();
+
             Events.Add(logEvent);
 
             if (ThrowAfterCollecting)


### PR DESCRIPTION
Also, use `GetConsumingEnumerable` to enumerate the queue, instead of a `while` loop