### PR TITLE
Cover blockWhenFull in README; update xUnit; minor tidying

### DIFF
--- a/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
+++ b/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
@@ -16,7 +16,7 @@ namespace Serilog
         /// <param name="loggerSinkConfiguration">The <see cref="LoggerSinkConfiguration"/> being configured.</param>
         /// <param name="configure">An action that configures the wrapped sink.</param>
         /// <param name="bufferSize">The size of the concurrent queue used to feed the background worker thread. If
-        /// the thread is unable to process events quickly enough and the queue is filled, subsequent events will be 
+        /// the thread is unable to process events quickly enough and the queue is filled, subsequent events will be
         /// dropped until room is made in the queue.</param>
         /// <returns>A <see cref="LoggerConfiguration"/> allowing configuration to continue.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -34,8 +34,8 @@ namespace Serilog
         /// <param name="loggerSinkConfiguration">The <see cref="LoggerSinkConfiguration"/> being configured.</param>
         /// <param name="configure">An action that configures the wrapped sink.</param>
         /// <param name="bufferSize">The size of the concurrent queue used to feed the background worker thread. If
-        /// the thread is unable to process events quickly enough and the queue is filled, depending on 
-        /// <paramref name="blockWhenFull"/> the queue will block or subsequent events will be dropped until 
+        /// the thread is unable to process events quickly enough and the queue is filled, depending on
+        /// <paramref name="blockWhenFull"/> the queue will block or subsequent events will be dropped until
         /// room is made in the queue.</param>
         /// <param name="blockWhenFull">Block when the queue is full, instead of dropping events.</param>
         /// <returns>A <see cref="LoggerConfiguration"/> allowing configuration to continue.</returns>

--- a/test/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
+++ b/test/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
@@ -18,8 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="BenchmarkDotNet" Version="0.10.6" />
     <PackageReference Include="Serilog.Sinks.File" Version="3.1.0" />
   </ItemGroup>

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkIntegrationSpec.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkIntegrationSpec.cs
@@ -130,7 +130,7 @@ namespace Serilog.Sinks.Async.Tests
 
                 var result = RetrieveEvents(_memorySink, 1);
 
-                Assert.Equal(1, result.Count);
+                Assert.Single(result);
             }
 
             [Fact]

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
@@ -39,7 +39,7 @@ namespace Serilog.Sinks.Async.Tests
 
                 await Task.Delay(TimeSpan.FromSeconds(3));
 
-                Assert.Equal(1, _innerSink.Events.Count);
+                Assert.Single(_innerSink.Events);
             }
         }
 
@@ -88,7 +88,7 @@ namespace Serilog.Sinks.Async.Tests
         {
             using (var sink = new BackgroundWorkerSink(_logger, 1, false))
             {
-                // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity 
+                // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity
                 // after the first event is popped
                 _innerSink.DelayEmit = TimeSpan.FromMilliseconds(300);
 
@@ -109,7 +109,7 @@ namespace Serilog.Sinks.Async.Tests
                     Assert.True(sw.ElapsedMilliseconds < 200, "Should not block the caller when the queue is full");
                 });
 
-                // If we *weren't* dropped events, the delay in the inner sink would mean the 5 events would take 
+                // If we *weren't* dropped events, the delay in the inner sink would mean the 5 events would take
                 // at least 15 seconds to process
                 await Task.Delay(TimeSpan.FromSeconds(2));
 
@@ -123,7 +123,7 @@ namespace Serilog.Sinks.Async.Tests
         {
             using (var sink = new BackgroundWorkerSink(_logger, 1, true))
             {
-                // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity 
+                // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity
                 // after the first event is popped
                 _innerSink.DelayEmit = TimeSpan.FromMilliseconds(300);
 
@@ -141,7 +141,7 @@ namespace Serilog.Sinks.Async.Tests
                     sink.Emit(e);
                     sw.Stop();
 
-                    // Emit should return immediately the first time, since the queue is not yet full. On 
+                    // Emit should return immediately the first time, since the queue is not yet full. On
                     // subsequent calls, the queue should be full, so we should be blocked
                     if (i > 0)
                     {

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkTests.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkTests.cs
@@ -32,7 +32,7 @@ namespace Serilog.Sinks.Async.Tests
             {
             }
 
-            Assert.Equal(0, collector.Events.Count);
+            Assert.Empty(collector.Events);
         }
     }
 }

--- a/test/Serilog.Sinks.Async.Tests/Serilog.Sinks.Async.Tests.csproj
+++ b/test/Serilog.Sinks.Async.Tests/Serilog.Sinks.Async.Tests.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR is a grab-bag of cleanup work, which arose in preparation work for #29 :- 
- document `blockWhenFull` (added in #21)
- update xUnit to 2.3.1 (so it runs correctly in VS2017) (includes addressing warnings emitted by its validator)
- minor reformatting
