### PR TITLE
Update to Serilog v2.7.1 to fix various sink wrapping issues

### DIFF
--- a/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
+++ b/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Serilog.Configuration;
 using Serilog.Sinks.Async;
+using Serilog.Events;
 
 namespace Serilog
 {
@@ -71,7 +72,9 @@ namespace Serilog
             return LoggerSinkConfiguration.Wrap(
                 loggerSinkConfiguration,
                 wrappedSink => new BackgroundWorkerSink(wrappedSink, bufferSize, blockWhenFull, monitor),
-                configure);
+                configure,
+                LevelAlias.Minimum,
+                null);
         }
     }
 }

--- a/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
+++ b/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
@@ -3,12 +3,13 @@
   <PropertyGroup>
     <Description>Asynchronous sink wrapper for Serilog.</Description>
     <AssemblyVersion>1.0.0</AssemblyVersion>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Jezz Santos;Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Async</AssemblyName>
+    <RootNamespace>Serilog</RootNamespace>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -18,12 +19,15 @@
     <PackageProjectUrl>https://serilog.net</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <!-- Don't reference the full NETStandard.Library -->
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
-
+  
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
@@ -32,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <PackageReference Include="System.Collections.Concurrent" Version="4.0.12" />
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
+++ b/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
@@ -35,8 +35,4 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This change explicitly specifies the _Serilog_ version that includes serilog/serilog#1165, fixing a number of issues with the `LoggerSinkConfiguration.Wrap()` method that's used by `Async()` behind the scenes.

Addresses some minor project setup issues, and aligns with _Serilog_'s use of _NETStandard.Library_ on the non-.NET Framework platforms.