### PR TITLE
Ensure we handle exceptions from the wrapped sink

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: '{build}'
 skip_tags: true
 image: Visual Studio 2017
-configuration: Release
 build_script:
 - ps: ./Build.ps1
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2017
+image: Visual Studio 2019
 build_script:
 - ps: ./Build.ps1
 test: off

--- a/serilog-sinks-async.sln.DotSettings
+++ b/serilog-sinks-async.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
+++ b/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <Description>Asynchronous sink wrapper for Serilog.</Description>
-    <AssemblyVersion>1.3.1.0</AssemblyVersion>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <Authors>Jezz Santos;Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;net461;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Async</AssemblyName>
@@ -15,7 +15,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Serilog.Sinks.Async</PackageId>
     <PackageTags>serilog;async</PackageTags>
-    <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
+    <PackageIconUrl>https://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://serilog.net</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-async</RepositoryUrl>
@@ -23,16 +23,16 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' ">
     <!-- Don't reference the full NETStandard.Library -->
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
+++ b/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
@@ -17,7 +17,7 @@
     <PackageTags>serilog;async</PackageTags>
     <PackageIconUrl>https://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://serilog.net</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicense>Apache-2.0</PackageLicense>
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-async</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/test/Serilog.Sinks.Async.PerformanceTests/LatencyBenchmark.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/LatencyBenchmark.cs
@@ -11,17 +11,17 @@ namespace Serilog.Sinks.Async.PerformanceTests
 {
     public class LatencyBenchmark
     {
-        private readonly LogEvent _evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
+        readonly LogEvent _evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
             new MessageTemplate(new[] {new TextToken("Hello")}), new LogEventProperty[0]);
 
-        private Logger _syncLogger, _asyncLogger, _fileLogger, _asyncFileLogger;
+        Logger _syncLogger, _asyncLogger, _fileLogger, _asyncFileLogger;
 
         static LatencyBenchmark()
         {
             SelfLog.Enable(new TerminatingTextWriter());
         }
 
-        [Setup]
+        [GlobalSetup]
         public void Reset()
         {
             foreach (var logger in new[] { _syncLogger, _asyncLogger, _fileLogger, _asyncFileLogger})

--- a/test/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
+++ b/test/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Async.PerformanceTests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -17,10 +17,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Include="Serilog.Sinks.File" Version="3.1.0" />
   </ItemGroup>
 

--- a/test/Serilog.Sinks.Async.PerformanceTests/SignallingSink.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/SignallingSink.cs
@@ -5,11 +5,11 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.Async.PerformanceTests
 {
-    internal class SignallingSink : ILogEventSink
+    class SignallingSink : ILogEventSink
     {
-        private readonly int _expectedCount;
-        private readonly ManualResetEvent _wh;
-        private int _current;
+        readonly int _expectedCount;
+        readonly ManualResetEvent _wh;
+        int _current;
 
         public SignallingSink(int expectedCount)
         {

--- a/test/Serilog.Sinks.Async.PerformanceTests/ThroughputBenchmark.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/ThroughputBenchmark.cs
@@ -8,20 +8,20 @@ namespace Serilog.Sinks.Async.PerformanceTests
 {
     public class ThroughputBenchmark
     {
-        private const int Count = 10000;
+        const int Count = 10000;
 
-        private readonly LogEvent _evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
+        readonly LogEvent _evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
             new MessageTemplate(new[] {new TextToken("Hello")}), new LogEventProperty[0]);
 
-        private readonly SignallingSink _signal;
-        private Logger _syncLogger, _asyncLogger;
+        readonly SignallingSink _signal;
+        Logger _syncLogger, _asyncLogger;
 
         public ThroughputBenchmark()
         {
             _signal = new SignallingSink(Count);
         }
 
-        [Setup]
+        [GlobalSetup]
         public void Reset()
         {
             _syncLogger?.Dispose();

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkIntegrationSpec.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkIntegrationSpec.cs
@@ -15,7 +15,7 @@ namespace Serilog.Sinks.Async.Tests
         /// <summary>
         ///     If <see cref="withDelay" />, then adds a 1sec delay before every fifth element created
         /// </summary>
-        private static void CreateAudits(ILogger logger, int count, bool withDelay)
+        static void CreateAudits(ILogger logger, int count, bool withDelay)
         {
             var delay = TimeSpan.FromMilliseconds(1000);
             var sw = new Stopwatch();
@@ -47,7 +47,7 @@ namespace Serilog.Sinks.Async.Tests
             }
         }
 
-        private static List<LogEvent> RetrieveEvents(MemorySink sink, int count)
+        static List<LogEvent> RetrieveEvents(MemorySink sink, int count)
         {
             Debug.WriteLine("{0:h:mm:ss tt} Retrieving {1} events", DateTime.Now, count);
 
@@ -91,9 +91,9 @@ namespace Serilog.Sinks.Async.Tests
 
         public abstract class SinkSpecBase : IDisposable
         {
-            private bool _delayCreation;
-            private Logger _logger;
-            private MemorySink _memorySink;
+            bool _delayCreation;
+            Logger _logger;
+            MemorySink _memorySink;
 
             protected SinkSpecBase(bool useBufferedQueue, bool delayCreation)
             {

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
@@ -230,12 +230,12 @@ namespace Serilog.Sinks.Async.Tests
             Assert.Null(monitor.Inspector);
         }
 
-        private BackgroundWorkerSink CreateSinkWithDefaultOptions()
+        BackgroundWorkerSink CreateSinkWithDefaultOptions()
         {
             return new BackgroundWorkerSink(_logger, 10000, false);
         }
 
-        private static LogEvent CreateEvent()
+        static LogEvent CreateEvent()
         {
             return new LogEvent(DateTimeOffset.MaxValue, LogEventLevel.Error, null,
                 new MessageTemplate("amessage", Enumerable.Empty<MessageTemplateToken>()),

--- a/test/Serilog.Sinks.Async.Tests/Serilog.Sinks.Async.Tests.csproj
+++ b/test/Serilog.Sinks.Async.Tests/Serilog.Sinks.Async.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Async.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -14,9 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Originally, `_pipeline` was a logger, and therefore exceptions from the target sink were suppressed. After switching to invoke the wrapped sink directly, these escape and terminate the worker.

I did my best to modernize the package where I could, on a drive-by. This means adding netstandard2.0 and net461 targets, as well as some dependency updates.

_Should_ be pretty safe to get this out there :-)

Fixes #44