### PR TITLE
Bump Serilog version dependency to support Unity and .netstandard 2.0+

### DIFF
--- a/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
+++ b/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' ">


### PR DESCRIPTION
Same problem as this

https://github.com/serilog/serilog-extensions-logging/pull/188