### PR TITLE
Fixed a small typo in the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ var monitor = new MonitorConfiguration();
 
 ### Blocking
 
-Warning: For the same reason one typically does not want exceptions from logging to leak into the execution path, one typically does not want a logger to be able to have the side-efect of actually interrupting application processing until the log propagation has been unblocked.
+Warning: For the same reason one typically does not want exceptions from logging to leak into the execution path, one typically does not want a logger to be able to have the side-effect of actually interrupting application processing until the log propagation has been unblocked.
 
 When the buffer size limit is reached, the default behavior is to drop any further attempted writes until the queue abates, reporting each such failure to the `Serilog.Debugging.SelfLog`. To replace this with a blocking behaviour, set `blockWhenFull` to `true`.
 


### PR DESCRIPTION
While looking through the README I spotted a typo, so I thought I'd fix it.

`side-efect` -> `side-effect`