### PR TITLE
Serilog 4 updates

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -11,33 +11,25 @@ if(Test-Path .\artifacts) {
 
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
 $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
-$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
+$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "main" -and $revision -ne "local"]
+$commitHash = $(git rev-parse --short HEAD)
+$buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 
-echo "build: Version suffix is $suffix"
+echo "build: Package version suffix is $suffix"
+echo "build: Build version suffix is $buildSuffix" 
 
 foreach ($src in ls src/*) {
     Push-Location $src
 
-    echo "build: Packaging project in $src"
+	echo "build: Packaging project in $src"
 
+    & dotnet build -c Release --version-suffix=$buildSuffix -p:EnableSourceLink=true
     if ($suffix) {
-        & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix --include-source
+        & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix --no-build
     } else {
-        & dotnet pack -c Release -o ..\..\artifacts --include-source
+        & dotnet pack -c Release -o ..\..\artifacts --no-build
     }
-    
     if($LASTEXITCODE -ne 0) { exit 1 }    
-
-    Pop-Location
-}
-
-foreach ($test in ls test/*.PerformanceTests) {
-    Push-Location $test
-
-    echo "build: Building performance test project in $test"
-
-    & dotnet build -c Release
-    if($LASTEXITCODE -ne 0) { exit 2 }
 
     Pop-Location
 }
@@ -45,7 +37,7 @@ foreach ($test in ls test/*.PerformanceTests) {
 foreach ($test in ls test/*.Tests) {
     Push-Location $test
 
-    echo "build: Testing project in $test"
+	echo "build: Testing project in $test"
 
     & dotnet test -c Release
     if($LASTEXITCODE -ne 0) { exit 3 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2022
 build_script:
-- ps: ./Build.ps1
+- pwsh: ./Build.ps1
 test: off
 artifacts:
 - path: artifacts/Serilog.*.nupkg

--- a/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
+++ b/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.ComponentModel;
 using Serilog.Configuration;
 using Serilog.Sinks.Async;
-using Serilog.Events;
 
 namespace Serilog
 {
@@ -11,44 +9,6 @@ namespace Serilog
     /// </summary>
     public static class LoggerConfigurationAsyncExtensions
     {
-        /// <summary>
-        /// Configure a sink to be invoked asynchronously, on a background worker thread.
-        /// </summary>
-        /// <param name="loggerSinkConfiguration">The <see cref="LoggerSinkConfiguration"/> being configured.</param>
-        /// <param name="configure">An action that configures the wrapped sink.</param>
-        /// <param name="bufferSize">The size of the concurrent queue used to feed the background worker thread. If
-        /// the thread is unable to process events quickly enough and the queue is filled, subsequent events will be
-        /// dropped until room is made in the queue.</param>
-        /// <returns>A <see cref="LoggerConfiguration"/> allowing configuration to continue.</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static LoggerConfiguration Async(
-            this LoggerSinkConfiguration loggerSinkConfiguration,
-            Action<LoggerSinkConfiguration> configure,
-            int bufferSize)
-        {
-            return loggerSinkConfiguration.Async(configure, bufferSize, false);
-        }
-
-        /// <summary>
-        /// Configure a sink to be invoked asynchronously, on a background worker thread.
-        /// </summary>
-        /// <param name="loggerSinkConfiguration">The <see cref="LoggerSinkConfiguration"/> being configured.</param>
-        /// <param name="configure">An action that configures the wrapped sink.</param>
-        /// <param name="bufferSize">The size of the concurrent queue used to feed the background worker thread. If
-        /// the thread is unable to process events quickly enough and the queue is filled, depending on
-        /// <paramref name="blockWhenFull"/> the queue will block or subsequent events will be dropped until
-        /// room is made in the queue.</param>
-        /// <param name="blockWhenFull">Block when the queue is full, instead of dropping events.</param>
-        /// <returns>A <see cref="LoggerConfiguration"/> allowing configuration to continue.</returns>
-        public static LoggerConfiguration Async(
-            this LoggerSinkConfiguration loggerSinkConfiguration,
-            Action<LoggerSinkConfiguration> configure,
-            int bufferSize = 10000,
-            bool blockWhenFull = false)
-        {
-            return loggerSinkConfiguration.Async(configure, null, bufferSize, blockWhenFull);
-        }
-
         /// <summary>
         /// Configure a sink to be invoked asynchronously, on a background worker thread.
         /// Accepts a reference to a <paramref name="monitor"/> that will be supplied the internal state interface for health monitoring purposes.
@@ -65,16 +25,14 @@ namespace Serilog
         public static LoggerConfiguration Async(
             this LoggerSinkConfiguration loggerSinkConfiguration,
             Action<LoggerSinkConfiguration> configure,
-            IAsyncLogEventSinkMonitor monitor,
             int bufferSize = 10000,
-            bool blockWhenFull = false)
+            bool blockWhenFull = false,
+            IAsyncLogEventSinkMonitor? monitor = null)
         {
-            return LoggerSinkConfiguration.Wrap(
-                loggerSinkConfiguration,
+            var wrapper = LoggerSinkConfiguration.Wrap(
                 wrappedSink => new BackgroundWorkerSink(wrappedSink, bufferSize, blockWhenFull, monitor),
-                configure,
-                LevelAlias.Minimum,
-                null);
+                configure);
+            return loggerSinkConfiguration.Sink(wrapper);
         }
     }
 }

--- a/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
+++ b/src/Serilog.Sinks.Async/LoggerConfigurationAsyncExtensions.cs
@@ -1,38 +1,51 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Serilog.Configuration;
 using Serilog.Sinks.Async;
 
-namespace Serilog
+namespace Serilog;
+
+/// <summary>
+/// Extends <see cref="LoggerConfiguration"/> with methods for configuring asynchronous logging.
+/// </summary>
+public static class LoggerConfigurationAsyncExtensions
 {
     /// <summary>
-    /// Extends <see cref="LoggerConfiguration"/> with methods for configuring asynchronous logging.
+    /// Configure a sink to be invoked asynchronously, on a background worker thread.
+    /// Accepts a reference to a <paramref name="monitor"/> that will be supplied the internal state interface for health monitoring purposes.
     /// </summary>
-    public static class LoggerConfigurationAsyncExtensions
+    /// <param name="loggerSinkConfiguration">The <see cref="LoggerSinkConfiguration"/> being configured.</param>
+    /// <param name="configure">An action that configures the wrapped sink.</param>
+    /// <param name="bufferSize">The size of the concurrent queue used to feed the background worker thread. If
+    /// the thread is unable to process events quickly enough and the queue is filled, depending on
+    /// <paramref name="blockWhenFull"/> the queue will block or subsequent events will be dropped until
+    /// room is made in the queue.</param>
+    /// <param name="blockWhenFull">Block when the queue is full, instead of dropping events.</param>
+    /// <param name="monitor">Monitor to supply buffer information to.</param>
+    /// <returns>A <see cref="LoggerConfiguration"/> allowing configuration to continue.</returns>
+    public static LoggerConfiguration Async(
+        this LoggerSinkConfiguration loggerSinkConfiguration,
+        Action<LoggerSinkConfiguration> configure,
+        int bufferSize = 10000,
+        bool blockWhenFull = false,
+        IAsyncLogEventSinkMonitor? monitor = null)
     {
-        /// <summary>
-        /// Configure a sink to be invoked asynchronously, on a background worker thread.
-        /// Accepts a reference to a <paramref name="monitor"/> that will be supplied the internal state interface for health monitoring purposes.
-        /// </summary>
-        /// <param name="loggerSinkConfiguration">The <see cref="LoggerSinkConfiguration"/> being configured.</param>
-        /// <param name="configure">An action that configures the wrapped sink.</param>
-        /// <param name="bufferSize">The size of the concurrent queue used to feed the background worker thread. If
-        /// the thread is unable to process events quickly enough and the queue is filled, depending on
-        /// <paramref name="blockWhenFull"/> the queue will block or subsequent events will be dropped until
-        /// room is made in the queue.</param>
-        /// <param name="blockWhenFull">Block when the queue is full, instead of dropping events.</param>
-        /// <param name="monitor">Monitor to supply buffer information to.</param>
-        /// <returns>A <see cref="LoggerConfiguration"/> allowing configuration to continue.</returns>
-        public static LoggerConfiguration Async(
-            this LoggerSinkConfiguration loggerSinkConfiguration,
-            Action<LoggerSinkConfiguration> configure,
-            int bufferSize = 10000,
-            bool blockWhenFull = false,
-            IAsyncLogEventSinkMonitor? monitor = null)
-        {
-            var wrapper = LoggerSinkConfiguration.Wrap(
-                wrappedSink => new BackgroundWorkerSink(wrappedSink, bufferSize, blockWhenFull, monitor),
-                configure);
-            return loggerSinkConfiguration.Sink(wrapper);
-        }
+        var wrapper = LoggerSinkConfiguration.Wrap(
+            wrappedSink => new BackgroundWorkerSink(wrappedSink, bufferSize, blockWhenFull, monitor),
+            configure);
+        return loggerSinkConfiguration.Sink(wrapper);
     }
 }

--- a/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
+++ b/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
@@ -2,17 +2,20 @@
 
   <PropertyGroup>
     <Description>Asynchronous sink wrapper for Serilog.</Description>
-    <VersionPrefix>1.5.1</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Jezz Santos;Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.1;net461;netstandard2.0</TargetFrameworks>
+    <!-- .NET Framework version targeting is frozen at these two TFMs. -->
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net471;net462</TargetFrameworks>
+    <!-- Policy is to trim TFM-specific builds to `netstandard2.0`, `net6.0`,
+    all active LTS versions, and optionally the latest RTM version, when releasing new
+    major Serilog versions. -->
+    <TargetFrameworks>$(TargetFrameworks);net8.0;net6.0;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>Serilog.Sinks.Async</AssemblyName>
     <RootNamespace>Serilog</RootNamespace>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>Serilog.Sinks.Async</PackageId>
     <PackageTags>serilog;async</PackageTags>
     <PackageIcon>serilog-sink-nuget.png</PackageIcon>
     <PackageProjectUrl>https://serilog.net</PackageProjectUrl>
@@ -20,27 +23,29 @@
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-async</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' ">
-    <!-- Don't reference the full NETStandard.Library -->
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-  
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\assets\serilog-sink-nuget.png">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
+    <None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="/" />
+    <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="/" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
+++ b/src/Serilog.Sinks.Async/Serilog.Sinks.Async.csproj
@@ -33,16 +33,6 @@
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="/" />
     <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="/" />

--- a/src/Serilog.Sinks.Async/Sinks/Async/BackgroundWorkerSink.cs
+++ b/src/Serilog.Sinks.Async/Sinks/Async/BackgroundWorkerSink.cs
@@ -14,11 +14,11 @@ namespace Serilog.Sinks.Async
         readonly bool _blockWhenFull;
         readonly BlockingCollection<LogEvent> _queue;
         readonly Task _worker;
-        readonly IAsyncLogEventSinkMonitor _monitor;
+        readonly IAsyncLogEventSinkMonitor? _monitor;
 
         long _droppedMessages;
 
-        public BackgroundWorkerSink(ILogEventSink wrappedSink, int bufferCapacity, bool blockWhenFull, IAsyncLogEventSinkMonitor monitor = null)
+        public BackgroundWorkerSink(ILogEventSink wrappedSink, int bufferCapacity, bool blockWhenFull, IAsyncLogEventSinkMonitor? monitor = null)
         {
             if (bufferCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(bufferCapacity));
             _wrappedSink = wrappedSink ?? throw new ArgumentNullException(nameof(wrappedSink));

--- a/src/Serilog.Sinks.Async/Sinks/Async/BackgroundWorkerSink.cs
+++ b/src/Serilog.Sinks.Async/Sinks/Async/BackgroundWorkerSink.cs
@@ -32,7 +32,7 @@ sealed class BackgroundWorkerSink : ILogEventSink, IAsyncLogEventSinkInspector, 
 
     long _droppedMessages;
 
-    public BackgroundWorkerSink(ILogEventSink wrappedSink, int bufferCapacity, bool blockWhenFull, IAsyncLogEventSinkMonitor? monitor = null)
+    public BackgroundWorkerSink(ILogEventSink wrappedSink, int bufferCapacity, bool blockWhenFull, IAsyncLogEventSinkMonitor? monitor)
     {
         if (bufferCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(bufferCapacity));
         _wrappedSink = wrappedSink ?? throw new ArgumentNullException(nameof(wrappedSink));

--- a/src/Serilog.Sinks.Async/Sinks/Async/BackgroundWorkerSink.cs
+++ b/src/Serilog.Sinks.Async/Sinks/Async/BackgroundWorkerSink.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,95 +20,94 @@ using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
 
-namespace Serilog.Sinks.Async
+namespace Serilog.Sinks.Async;
+
+sealed class BackgroundWorkerSink : ILogEventSink, IAsyncLogEventSinkInspector, IDisposable
 {
-    sealed class BackgroundWorkerSink : ILogEventSink, IAsyncLogEventSinkInspector, IDisposable
+    readonly ILogEventSink _wrappedSink;
+    readonly bool _blockWhenFull;
+    readonly BlockingCollection<LogEvent> _queue;
+    readonly Task _worker;
+    readonly IAsyncLogEventSinkMonitor? _monitor;
+
+    long _droppedMessages;
+
+    public BackgroundWorkerSink(ILogEventSink wrappedSink, int bufferCapacity, bool blockWhenFull, IAsyncLogEventSinkMonitor? monitor = null)
     {
-        readonly ILogEventSink _wrappedSink;
-        readonly bool _blockWhenFull;
-        readonly BlockingCollection<LogEvent> _queue;
-        readonly Task _worker;
-        readonly IAsyncLogEventSinkMonitor? _monitor;
-
-        long _droppedMessages;
-
-        public BackgroundWorkerSink(ILogEventSink wrappedSink, int bufferCapacity, bool blockWhenFull, IAsyncLogEventSinkMonitor? monitor = null)
-        {
-            if (bufferCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(bufferCapacity));
-            _wrappedSink = wrappedSink ?? throw new ArgumentNullException(nameof(wrappedSink));
-            _blockWhenFull = blockWhenFull;
-            _queue = new BlockingCollection<LogEvent>(bufferCapacity);
-            _worker = Task.Factory.StartNew(Pump, CancellationToken.None, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
-            _monitor = monitor;
-            monitor?.StartMonitoring(this);
-        }
-
-        public void Emit(LogEvent logEvent)
-        {
-            if (_queue.IsAddingCompleted)
-                return;
-
-            try
-            {
-                if (_blockWhenFull)
-                {
-                    _queue.Add(logEvent);
-                }
-                else
-                {
-                    if (!_queue.TryAdd(logEvent))
-                    {
-                        Interlocked.Increment(ref _droppedMessages);
-                        SelfLog.WriteLine("{0} unable to enqueue, capacity {1}", typeof(BackgroundWorkerSink), _queue.BoundedCapacity);
-                    }
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // Thrown in the event of a race condition when we try to add another event after
-                // CompleteAdding has been called
-            }
-        }
-
-        public void Dispose()
-        {
-            // Prevent any more events from being added
-            _queue.CompleteAdding();
-
-            // Allow queued events to be flushed
-            _worker.Wait();
-
-            (_wrappedSink as IDisposable)?.Dispose();
-
-            _monitor?.StopMonitoring(this);
-        }
-
-        void Pump()
-        {
-            try
-            {
-                foreach (var next in _queue.GetConsumingEnumerable())
-                {
-                    try
-                    {
-                        _wrappedSink.Emit(next);
-                    }
-                    catch (Exception ex)
-                    {
-                        SelfLog.WriteLine("{0} failed to emit event to wrapped sink: {1}", typeof(BackgroundWorkerSink), ex);
-                    }
-                }
-            }
-            catch (Exception fatal)
-            {
-                SelfLog.WriteLine("{0} fatal error in worker thread: {1}", typeof(BackgroundWorkerSink), fatal);
-            }
-        }
-
-        int IAsyncLogEventSinkInspector.BufferSize => _queue.BoundedCapacity;
-
-        int IAsyncLogEventSinkInspector.Count => _queue.Count;
-
-        long IAsyncLogEventSinkInspector.DroppedMessagesCount => _droppedMessages;
+        if (bufferCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(bufferCapacity));
+        _wrappedSink = wrappedSink ?? throw new ArgumentNullException(nameof(wrappedSink));
+        _blockWhenFull = blockWhenFull;
+        _queue = new BlockingCollection<LogEvent>(bufferCapacity);
+        _worker = Task.Factory.StartNew(Pump, CancellationToken.None, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+        _monitor = monitor;
+        monitor?.StartMonitoring(this);
     }
+
+    public void Emit(LogEvent logEvent)
+    {
+        if (_queue.IsAddingCompleted)
+            return;
+
+        try
+        {
+            if (_blockWhenFull)
+            {
+                _queue.Add(logEvent);
+            }
+            else
+            {
+                if (!_queue.TryAdd(logEvent))
+                {
+                    Interlocked.Increment(ref _droppedMessages);
+                    SelfLog.WriteLine("{0} unable to enqueue, capacity {1}", typeof(BackgroundWorkerSink), _queue.BoundedCapacity);
+                }
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Thrown in the event of a race condition when we try to add another event after
+            // CompleteAdding has been called
+        }
+    }
+
+    public void Dispose()
+    {
+        // Prevent any more events from being added
+        _queue.CompleteAdding();
+
+        // Allow queued events to be flushed
+        _worker.Wait();
+
+        (_wrappedSink as IDisposable)?.Dispose();
+
+        _monitor?.StopMonitoring(this);
+    }
+
+    void Pump()
+    {
+        try
+        {
+            foreach (var next in _queue.GetConsumingEnumerable())
+            {
+                try
+                {
+                    _wrappedSink.Emit(next);
+                }
+                catch (Exception ex)
+                {
+                    SelfLog.WriteLine("{0} failed to emit event to wrapped sink: {1}", typeof(BackgroundWorkerSink), ex);
+                }
+            }
+        }
+        catch (Exception fatal)
+        {
+            SelfLog.WriteLine("{0} fatal error in worker thread: {1}", typeof(BackgroundWorkerSink), fatal);
+        }
+    }
+
+    int IAsyncLogEventSinkInspector.BufferSize => _queue.BoundedCapacity;
+
+    int IAsyncLogEventSinkInspector.Count => _queue.Count;
+
+    long IAsyncLogEventSinkInspector.DroppedMessagesCount => _droppedMessages;
 }

--- a/src/Serilog.Sinks.Async/Sinks/Async/IAsyncLogEventSinkInspector.cs
+++ b/src/Serilog.Sinks.Async/Sinks/Async/IAsyncLogEventSinkInspector.cs
@@ -1,25 +1,38 @@
-﻿namespace Serilog.Sinks.Async
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Sinks.Async;
+
+/// <summary>
+/// Provides a way to inspect the state of Async wrapper's ingestion queue.
+/// </summary>
+public interface IAsyncLogEventSinkInspector
 {
     /// <summary>
-    /// Provides a way to inspect the state of Async wrapper's ingestion queue.
+    /// Configured maximum number of items permitted to be held in the buffer awaiting ingestion.
     /// </summary>
-    public interface IAsyncLogEventSinkInspector
-    {
-        /// <summary>
-        /// Configured maximum number of items permitted to be held in the buffer awaiting ingestion.
-        /// </summary>
-        /// <exception cref="T:System.ObjectDisposedException">The Sink has been disposed.</exception>
-        int BufferSize { get; }
+    /// <exception cref="T:System.ObjectDisposedException">The Sink has been disposed.</exception>
+    int BufferSize { get; }
 
-        /// <summary>
-        /// Current moment-in-time Count of items currently awaiting ingestion.
-        /// </summary>
-        /// <exception cref="T:System.ObjectDisposedException">The Sink has been disposed.</exception>
-        int Count { get; }
+    /// <summary>
+    /// Current moment-in-time Count of items currently awaiting ingestion.
+    /// </summary>
+    /// <exception cref="T:System.ObjectDisposedException">The Sink has been disposed.</exception>
+    int Count { get; }
 
-        /// <summary>
-        /// Accumulated number of messages dropped due to breaches of <see cref="BufferSize"/> limit.
-        /// </summary>
-        long DroppedMessagesCount { get; }
-    }
+    /// <summary>
+    /// Accumulated number of messages dropped due to breaches of <see cref="BufferSize"/> limit.
+    /// </summary>
+    long DroppedMessagesCount { get; }
 }

--- a/src/Serilog.Sinks.Async/Sinks/Async/IAsyncLogEventSinkMonitor.cs
+++ b/src/Serilog.Sinks.Async/Sinks/Async/IAsyncLogEventSinkMonitor.cs
@@ -1,5 +1,4 @@
-﻿namespace Serilog.Sinks.Async;
-// Copyright © Serilog Contributors
+﻿// Copyright © Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+namespace Serilog.Sinks.Async;
 
 /// <summary>
 /// Defines a mechanism for the Async Sink to afford Health Checks a buffer metadata inspection mechanism.

--- a/src/Serilog.Sinks.Async/Sinks/Async/IAsyncLogEventSinkMonitor.cs
+++ b/src/Serilog.Sinks.Async/Sinks/Async/IAsyncLogEventSinkMonitor.cs
@@ -1,20 +1,32 @@
-﻿namespace Serilog.Sinks.Async
+﻿namespace Serilog.Sinks.Async;
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// <summary>
+/// Defines a mechanism for the Async Sink to afford Health Checks a buffer metadata inspection mechanism.
+/// </summary>
+public interface IAsyncLogEventSinkMonitor
 {
     /// <summary>
-    /// Defines a mechanism for the Async Sink to afford Health Checks a buffer metadata inspection mechanism.
+    /// Invoked by Sink to supply the inspector to the monitor.
     /// </summary>
-    public interface IAsyncLogEventSinkMonitor
-    {
-        /// <summary>
-        /// Invoked by Sink to supply the inspector to the monitor.
-        /// </summary>
-        /// <param name="inspector">The Async Sink's inspector.</param>
-        void StartMonitoring(IAsyncLogEventSinkInspector inspector);
+    /// <param name="inspector">The Async Sink's inspector.</param>
+    void StartMonitoring(IAsyncLogEventSinkInspector inspector);
 
-        /// <summary>
-        /// Invoked by Sink to indicate that it is being Disposed.
-        /// </summary>
-        /// <param name="inspector">The Async Sink's inspector.</param>
-        void StopMonitoring(IAsyncLogEventSinkInspector inspector);
-    }
+    /// <summary>
+    /// Invoked by Sink to indicate that it is being Disposed.
+    /// </summary>
+    /// <param name="inspector">The Async Sink's inspector.</param>
+    void StopMonitoring(IAsyncLogEventSinkInspector inspector);
 }

--- a/test/Serilog.Sinks.Async.PerformanceTests/Benchmarks.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/Benchmarks.cs
@@ -1,15 +1,14 @@
 ﻿using BenchmarkDotNet.Running;
 using Xunit;
 
-namespace Serilog.Sinks.Async.PerformanceTests
+namespace Serilog.Sinks.Async.PerformanceTests;
+
+public class Benchmarks
 {
-    public class Benchmarks
+    [Fact]
+    public void Benchmark()
     {
-        [Fact]
-        public void Benchmark()
-        {
-            BenchmarkRunner.Run<ThroughputBenchmark>();
-            BenchmarkRunner.Run<LatencyBenchmark>();
-        }
+        BenchmarkRunner.Run<ThroughputBenchmark>();
+        BenchmarkRunner.Run<LatencyBenchmark>();
     }
 }

--- a/test/Serilog.Sinks.Async.PerformanceTests/LatencyBenchmark.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/LatencyBenchmark.cs
@@ -7,72 +7,71 @@ using Serilog.Events;
 using Serilog.Parsing;
 using Serilog.Sinks.Async.PerformanceTests.Support;
 
-namespace Serilog.Sinks.Async.PerformanceTests
+namespace Serilog.Sinks.Async.PerformanceTests;
+
+public class LatencyBenchmark
 {
-    public class LatencyBenchmark
+    readonly LogEvent _evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
+        new MessageTemplate(new[] {new TextToken("Hello")}), new LogEventProperty[0]);
+
+    Logger _syncLogger, _asyncLogger, _fileLogger, _asyncFileLogger;
+
+    static LatencyBenchmark()
     {
-        readonly LogEvent _evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
-            new MessageTemplate(new[] {new TextToken("Hello")}), new LogEventProperty[0]);
+        SelfLog.Enable(new TerminatingTextWriter());
+    }
 
-        Logger _syncLogger, _asyncLogger, _fileLogger, _asyncFileLogger;
-
-        static LatencyBenchmark()
+    [GlobalSetup]
+    public void Reset()
+    {
+        foreach (var logger in new[] { _syncLogger, _asyncLogger, _fileLogger, _asyncFileLogger})
         {
-            SelfLog.Enable(new TerminatingTextWriter());
+            logger?.Dispose();
         }
 
-        [GlobalSetup]
-        public void Reset()
+        foreach (var tmp in Directory.GetFiles(".", "*.tmplog"))
         {
-            foreach (var logger in new[] { _syncLogger, _asyncLogger, _fileLogger, _asyncFileLogger})
-            {
-                logger?.Dispose();
-            }
-
-            foreach (var tmp in Directory.GetFiles(".", "*.tmplog"))
-            {
-                System.IO.File.Delete(tmp);
-            }
-
-            _syncLogger = new LoggerConfiguration()
-                .WriteTo.Sink(new SilentSink())
-                .CreateLogger();
-
-            _asyncLogger = new LoggerConfiguration()
-                .WriteTo.Async(a => a.Sink(new SilentSink()), 10000000)
-                .CreateLogger();
-
-            _fileLogger = new LoggerConfiguration()
-                .WriteTo.File("sync-file.tmplog")
-                .CreateLogger();
-
-            _asyncFileLogger = new LoggerConfiguration()
-                .WriteTo.Async(a => a.File("async-file.tmplog"), 10000000)
-                .CreateLogger();
+            System.IO.File.Delete(tmp);
         }
 
-        [Benchmark(Baseline = true)]
-        public void Sync()
-        {
-            _syncLogger.Write(_evt);
-        }
+        _syncLogger = new LoggerConfiguration()
+            .WriteTo.Sink(new SilentSink())
+            .CreateLogger();
 
-        [Benchmark]
-        public void Async()
-        {
-            _asyncLogger.Write(_evt);
-        }
+        _asyncLogger = new LoggerConfiguration()
+            .WriteTo.Async(a => a.Sink(new SilentSink()), 10000000)
+            .CreateLogger();
 
-        [Benchmark]
-        public void File()
-        {
-            _fileLogger.Write(_evt);
-        }
+        _fileLogger = new LoggerConfiguration()
+            .WriteTo.File("sync-file.tmplog")
+            .CreateLogger();
 
-        [Benchmark]
-        public void AsyncFile()
-        {
-            _asyncFileLogger.Write(_evt);
-        }
+        _asyncFileLogger = new LoggerConfiguration()
+            .WriteTo.Async(a => a.File("async-file.tmplog"), 10000000)
+            .CreateLogger();
+    }
+
+    [Benchmark(Baseline = true)]
+    public void Sync()
+    {
+        _syncLogger.Write(_evt);
+    }
+
+    [Benchmark]
+    public void Async()
+    {
+        _asyncLogger.Write(_evt);
+    }
+
+    [Benchmark]
+    public void File()
+    {
+        _fileLogger.Write(_evt);
+    }
+
+    [Benchmark]
+    public void AsyncFile()
+    {
+        _asyncFileLogger.Write(_evt);
     }
 }

--- a/test/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
+++ b/test/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net48</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net6.0;net8.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/test/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
+++ b/test/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-    <AssemblyName>Serilog.Sinks.Async.PerformanceTests</AssemblyName>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -25,10 +24,6 @@
     </PackageReference>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Include="Serilog.Sinks.File" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
+++ b/test/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
@@ -16,14 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
-    <PackageReference Include="Serilog.Sinks.File" Version="3.1.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.Sinks.Async.PerformanceTests/SignallingSink.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/SignallingSink.cs
@@ -3,36 +3,35 @@ using System.Threading;
 using Serilog.Core;
 using Serilog.Events;
 
-namespace Serilog.Sinks.Async.PerformanceTests
+namespace Serilog.Sinks.Async.PerformanceTests;
+
+class SignallingSink : ILogEventSink
 {
-    class SignallingSink : ILogEventSink
+    readonly int _expectedCount;
+    readonly ManualResetEvent _wh;
+    int _current;
+
+    public SignallingSink(int expectedCount)
     {
-        readonly int _expectedCount;
-        readonly ManualResetEvent _wh;
-        int _current;
+        _expectedCount = expectedCount;
+        _wh = new ManualResetEvent(false);
+    }
 
-        public SignallingSink(int expectedCount)
-        {
-            _expectedCount = expectedCount;
-            _wh = new ManualResetEvent(false);
-        }
+    public void Emit(LogEvent logEvent)
+    {
+        if (Interlocked.Increment(ref _current) == _expectedCount)
+            _wh.Set();
+    }
 
-        public void Emit(LogEvent logEvent)
-        {
-            if (Interlocked.Increment(ref _current) == _expectedCount)
-                _wh.Set();
-        }
+    public void Reset()
+    {
+        _wh.Reset();
+        _current = 0;
+    }
 
-        public void Reset()
-        {
-            _wh.Reset();
-            _current = 0;
-        }
-
-        public void Wait()
-        {
-            if (!_wh.WaitOne(60000))
-                throw new TimeoutException("Event was not signaled within 60s.");
-        }
+    public void Wait()
+    {
+        if (!_wh.WaitOne(60000))
+            throw new TimeoutException("Event was not signaled within 60s.");
     }
 }

--- a/test/Serilog.Sinks.Async.PerformanceTests/SilentSink.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/SilentSink.cs
@@ -1,12 +1,11 @@
 using Serilog.Core;
 using Serilog.Events;
 
-namespace Serilog.Sinks.Async.PerformanceTests
+namespace Serilog.Sinks.Async.PerformanceTests;
+
+public class SilentSink : ILogEventSink
 {
-    public class SilentSink : ILogEventSink
+    public void Emit(LogEvent logEvent)
     {
-        public void Emit(LogEvent logEvent)
-        {
-        }
     }
 }

--- a/test/Serilog.Sinks.Async.PerformanceTests/Support/TerminatingTextWriter.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/Support/TerminatingTextWriter.cs
@@ -2,16 +2,15 @@
 using System.IO;
 using System.Text;
 
-namespace Serilog.Sinks.Async.PerformanceTests.Support
-{
-    public class TerminatingTextWriter : TextWriter
-    {
-        public override Encoding Encoding { get; } = Encoding.ASCII;
+namespace Serilog.Sinks.Async.PerformanceTests.Support;
 
-        public override void Write(char value)
-        {
-            Console.WriteLine("SelfLog triggered");
-            Environment.Exit(1);
-        }
+public class TerminatingTextWriter : TextWriter
+{
+    public override Encoding Encoding { get; } = Encoding.ASCII;
+
+    public override void Write(char value)
+    {
+        Console.WriteLine("SelfLog triggered");
+        Environment.Exit(1);
     }
 }

--- a/test/Serilog.Sinks.Async.PerformanceTests/ThroughputBenchmark.cs
+++ b/test/Serilog.Sinks.Async.PerformanceTests/ThroughputBenchmark.cs
@@ -4,26 +4,26 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Parsing;
 
-namespace Serilog.Sinks.Async.PerformanceTests
+namespace Serilog.Sinks.Async.PerformanceTests;
+
+public class ThroughputBenchmark
 {
-    public class ThroughputBenchmark
+    const int Count = 10000;
+
+    readonly LogEvent _evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
+        new MessageTemplate(new[] {new TextToken("Hello")}), new LogEventProperty[0]);
+
+    readonly SignallingSink _signal;
+    Logger _syncLogger, _asyncLogger;
+
+    public ThroughputBenchmark()
     {
-        const int Count = 10000;
-
-        readonly LogEvent _evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
-            new MessageTemplate(new[] {new TextToken("Hello")}), new LogEventProperty[0]);
-
-        readonly SignallingSink _signal;
-        Logger _syncLogger, _asyncLogger;
-
-        public ThroughputBenchmark()
-        {
             _signal = new SignallingSink(Count);
         }
 
-        [GlobalSetup]
-        public void Reset()
-        {
+    [GlobalSetup]
+    public void Reset()
+    {
             _syncLogger?.Dispose();
             _asyncLogger?.Dispose();
 
@@ -38,9 +38,9 @@ namespace Serilog.Sinks.Async.PerformanceTests
                 .CreateLogger();
         }
 
-        [Benchmark(Baseline = true)]
-        public void Sync()
-        {
+    [Benchmark(Baseline = true)]
+    public void Sync()
+    {
             for (var i = 0; i < Count; ++i)
             {
                 _syncLogger.Write(_evt);
@@ -50,9 +50,9 @@ namespace Serilog.Sinks.Async.PerformanceTests
             _signal.Wait();
         }
 
-        [Benchmark]
-        public void Async()
-        {
+    [Benchmark]
+    public void Async()
+    {
             for (var i = 0; i < Count; ++i)
             {
                 _asyncLogger.Write(_evt);
@@ -60,5 +60,4 @@ namespace Serilog.Sinks.Async.PerformanceTests
 
             _signal.Wait();
         }
-    }
 }

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkIntegrationSpec.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkIntegrationSpec.cs
@@ -10,59 +10,60 @@ using System.Linq;
 
 namespace Serilog.Sinks.Async.Tests;
 
-public class BackgroundWorkerSinkIntegrationSpec
+public static class BackgroundWorkerSinkIntegrationSpec
 {
     /// <summary>
     ///     If <see cref="withDelay" />, then adds a 1sec delay before every fifth element created
     /// </summary>
     static void CreateAudits(ILogger logger, int count, bool withDelay)
     {
-            var delay = TimeSpan.FromMilliseconds(1000);
-            var sw = new Stopwatch();
-            sw.Start();
-            Debug.WriteLine("{0:h:mm:ss tt} Start: Writing {1} audits", DateTime.Now, count);
-            try
+        var delay = TimeSpan.FromMilliseconds(1000);
+        var sw = new Stopwatch();
+        sw.Start();
+        Debug.WriteLine("{0:h:mm:ss tt} Start: Writing {1} audits", DateTime.Now, count);
+        try
+        {
+            var delayCount = 0;
+            Loop.For(counter =>
             {
-                var delayCount = 0;
-                Loop.For(counter =>
+                if (withDelay
+                    && counter > 0
+                    && counter % 5 == 0)
                 {
-                    if (withDelay
-                        && counter > 0
-                        && counter%5 == 0)
-                    {
-                        delayCount++;
-                        Debug.WriteLine("{0:h:mm:ss tt} Delay ({1}) after {2}th write, for {3:0.###}secs", DateTime.Now,
-                            delayCount, counter,
-                            delay.TotalSeconds);
-                        Thread.Sleep(delay);
-                    }
-                    logger.Information("{$Counter}", counter);
-                }, count);
-            }
-            finally
-            {
-                sw.Stop();
-                Debug.WriteLine("{0:h:mm:ss tt}   End: Writing {1} audits, taking {2:0.###}", DateTime.Now, count,
-                    sw.Elapsed.TotalSeconds);
-            }
+                    delayCount++;
+                    Debug.WriteLine("{0:h:mm:ss tt} Delay ({1}) after {2}th write, for {3:0.###}secs", DateTime.Now,
+                        delayCount, counter,
+                        delay.TotalSeconds);
+                    Thread.Sleep(delay);
+                }
+
+                logger.Information("{$Counter}", counter);
+            }, count);
         }
+        finally
+        {
+            sw.Stop();
+            Debug.WriteLine("{0:h:mm:ss tt}   End: Writing {1} audits, taking {2:0.###}", DateTime.Now, count,
+                sw.Elapsed.TotalSeconds);
+        }
+    }
 
     static List<LogEvent> RetrieveEvents(MemorySink sink, int count)
     {
-            Debug.WriteLine("{0:h:mm:ss tt} Retrieving {1} events", DateTime.Now, count);
+        Debug.WriteLine("{0:h:mm:ss tt} Retrieving {1} events", DateTime.Now, count);
 
-            Loop.Retry(() => sink.Events, events => events != null && events.Count >= count, TimeSpan.FromSeconds(1),
-                TimeSpan.FromSeconds(30));
+        Loop.Retry(() => sink.Events, events => events != null && events.Count >= count, TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(30));
 
-            return sink.Events.ToList();
-        }
+        return sink.Events.ToList();
+    }
 
     public class GivenNoBufferQueueAndNoDelays : SinkSpecBase
     {
         public GivenNoBufferQueueAndNoDelays()
             : base(false, false)
         {
-            }
+        }
     }
 
     public class GivenBufferQueueAndNoDelays : SinkSpecBase
@@ -70,7 +71,7 @@ public class BackgroundWorkerSinkIntegrationSpec
         public GivenBufferQueueAndNoDelays()
             : base(true, false)
         {
-            }
+        }
     }
 
     public class GivenNoBufferQueueAndDelays : SinkSpecBase
@@ -78,7 +79,7 @@ public class BackgroundWorkerSinkIntegrationSpec
         public GivenNoBufferQueueAndDelays()
             : base(false, true)
         {
-            }
+        }
     }
 
     public class GivenBufferQueueAndDelays : SinkSpecBase
@@ -86,81 +87,81 @@ public class BackgroundWorkerSinkIntegrationSpec
         public GivenBufferQueueAndDelays()
             : base(true, true)
         {
-            }
+        }
     }
 
     public abstract class SinkSpecBase : IDisposable
     {
-        bool _delayCreation;
-        Logger _logger;
-        MemorySink _memorySink;
+        readonly bool _delayCreation;
+        readonly Logger _logger;
+        readonly MemorySink _memorySink;
 
         protected SinkSpecBase(bool useBufferedQueue, bool delayCreation)
         {
-                _delayCreation = delayCreation;
+            _delayCreation = delayCreation;
 
-                _memorySink = new MemorySink();
+            _memorySink = new MemorySink();
 
-                if (useBufferedQueue)
-                {
-                    _logger = new LoggerConfiguration()
-                        .WriteTo.Async(a => a.Sink(_memorySink))
-                        .CreateLogger();
-                }
-                else
-                {
-                    _logger = new LoggerConfiguration()
-                        .WriteTo.Sink(_memorySink)
-                        .CreateLogger();
-                }
-
-                Debug.WriteLine("{0:h:mm:ss tt} Started test", DateTime.Now);
+            if (useBufferedQueue)
+            {
+                _logger = new LoggerConfiguration()
+                    .WriteTo.Async(a => a.Sink(_memorySink))
+                    .CreateLogger();
             }
+            else
+            {
+                _logger = new LoggerConfiguration()
+                    .WriteTo.Sink(_memorySink)
+                    .CreateLogger();
+            }
+
+            Debug.WriteLine("{0:h:mm:ss tt} Started test", DateTime.Now);
+        }
 
         public void Dispose()
         {
-                _logger.Dispose();
-                Debug.WriteLine("{0:h:mm:ss tt} Ended test", DateTime.Now);
-            }
+            _logger.Dispose();
+            Debug.WriteLine("{0:h:mm:ss tt} Ended test", DateTime.Now);
+        }
 
         [Fact]
         public void WhenAuditSingle_ThenQueued()
         {
-                CreateAudits(_logger, 1, _delayCreation);
+            CreateAudits(_logger, 1, _delayCreation);
 
-                var result = RetrieveEvents(_memorySink, 1);
+            var result = RetrieveEvents(_memorySink, 1);
 
-                Assert.Single(result);
-            }
+            Assert.Single(result);
+        }
 
         [Fact]
         public void WhenAuditTen_ThenQueued()
         {
-                CreateAudits(_logger, 10, _delayCreation);
+            CreateAudits(_logger, 10, _delayCreation);
 
-                var result = RetrieveEvents(_memorySink, 10);
+            var result = RetrieveEvents(_memorySink, 10);
 
-                Assert.Equal(10, result.Count);
-            }
+            Assert.Equal(10, result.Count);
+        }
 
         [Fact]
         public void WhenAuditHundred_ThenQueued()
         {
-                CreateAudits(_logger, 100, _delayCreation);
+            CreateAudits(_logger, 100, _delayCreation);
 
-                var result = RetrieveEvents(_memorySink, 100);
+            var result = RetrieveEvents(_memorySink, 100);
 
-                Assert.Equal(100, result.Count);
-            }
+            Assert.Equal(100, result.Count);
+        }
 
         [Fact]
         public void WhenAuditFiveHundred_ThenQueued()
         {
-                CreateAudits(_logger, 500, _delayCreation);
+            CreateAudits(_logger, 500, _delayCreation);
 
-                var result = RetrieveEvents(_memorySink, 500);
+            var result = RetrieveEvents(_memorySink, 500);
 
-                Assert.Equal(500, result.Count);
-            }
+            Assert.Equal(500, result.Count);
+        }
     }
 }

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
@@ -10,28 +10,28 @@ using Serilog.Parsing;
 using Serilog.Sinks.Async.Tests.Support;
 using Xunit;
 
-namespace Serilog.Sinks.Async.Tests
-{
-    public class BackgroundWorkerSinkSpec
-    {
-        readonly Logger _logger;
-        readonly MemorySink _innerSink;
+namespace Serilog.Sinks.Async.Tests;
 
-        public BackgroundWorkerSinkSpec()
-        {
+public class BackgroundWorkerSinkSpec
+{
+    readonly Logger _logger;
+    readonly MemorySink _innerSink;
+
+    public BackgroundWorkerSinkSpec()
+    {
             _innerSink = new MemorySink();
             _logger = new LoggerConfiguration().WriteTo.Sink(_innerSink).CreateLogger();
         }
 
-        [Fact]
-        public void WhenCtorWithNullSink_ThenThrows()
-        {
+    [Fact]
+    public void WhenCtorWithNullSink_ThenThrows()
+    {
             Assert.Throws<ArgumentNullException>(() => new BackgroundWorkerSink(null, 10000, false, null));
         }
 
-        [Fact]
-        public async Task WhenEmitSingle_ThenRelaysToInnerSink()
-        {
+    [Fact]
+    public async Task WhenEmitSingle_ThenRelaysToInnerSink()
+    {
             using (var sink = this.CreateSinkWithDefaultOptions())
             {
                 var logEvent = CreateEvent();
@@ -44,9 +44,9 @@ namespace Serilog.Sinks.Async.Tests
             }
         }
 
-        [Fact]
-        public async Task WhenInnerEmitThrows_ThenContinuesRelaysToInnerSink()
-        {
+    [Fact]
+    public async Task WhenInnerEmitThrows_ThenContinuesRelaysToInnerSink()
+    {
             using (var sink = this.CreateSinkWithDefaultOptions())
             {
                 _innerSink.ThrowAfterCollecting = true;
@@ -65,9 +65,9 @@ namespace Serilog.Sinks.Async.Tests
             }
         }
 
-        [Fact]
-        public async Task WhenEmitMultipleTimes_ThenRelaysToInnerSink()
-        {
+    [Fact]
+    public async Task WhenEmitMultipleTimes_ThenRelaysToInnerSink()
+    {
             using (var sink = this.CreateSinkWithDefaultOptions())
             {
                 var events = new List<LogEvent>
@@ -84,9 +84,9 @@ namespace Serilog.Sinks.Async.Tests
             }
         }
 
-        [Fact]
-        public async Task GivenDefaultConfig_WhenRequestsExceedCapacity_DoesNotBlock()
-        {
+    [Fact]
+    public async Task GivenDefaultConfig_WhenRequestsExceedCapacity_DoesNotBlock()
+    {
             var batchTiming = Stopwatch.StartNew();
             using (var sink = new BackgroundWorkerSink(_logger, 1, blockWhenFull: false /*default*/))
             {
@@ -115,9 +115,9 @@ namespace Serilog.Sinks.Async.Tests
             Assert.InRange(batchTiming.ElapsedMilliseconds, 950, 2050);
         }
 
-        [Fact]
-        public async Task GivenDefaultConfig_WhenRequestsExceedCapacity_ThenDropsEventsAndRecovers()
-        {
+    [Fact]
+    public async Task GivenDefaultConfig_WhenRequestsExceedCapacity_ThenDropsEventsAndRecovers()
+    {
             using (var sink = new BackgroundWorkerSink(_logger, 1, blockWhenFull: false /*default*/))
             {
                 var acceptInterval = TimeSpan.FromMilliseconds(200);
@@ -150,9 +150,9 @@ namespace Serilog.Sinks.Async.Tests
             }
         }
 
-        [Fact]
-        public async Task GivenConfiguredToBlock_WhenQueueFilled_ThenBlocks()
-        {
+    [Fact]
+    public async Task GivenConfiguredToBlock_WhenQueueFilled_ThenBlocks()
+    {
             using (var sink = new BackgroundWorkerSink(_logger, 1, blockWhenFull: true))
             {
                 // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity
@@ -189,9 +189,9 @@ namespace Serilog.Sinks.Async.Tests
             }
         }
 
-        [Fact]
-        public void MonitorParameterAffordsSinkInspectorSuitableForHealthChecking()
-        {
+    [Fact]
+    public void MonitorParameterAffordsSinkInspectorSuitableForHealthChecking()
+    {
             var collector = new MemorySink { DelayEmit = TimeSpan.FromSeconds(2) };
             // 2 spaces in queue; 1 would make the second log entry eligible for dropping if consumer does not activate instantaneously
             var bufferSize = 2;
@@ -230,16 +230,15 @@ namespace Serilog.Sinks.Async.Tests
             Assert.Null(monitor.Inspector);
         }
 
-        BackgroundWorkerSink CreateSinkWithDefaultOptions()
-        {
+    BackgroundWorkerSink CreateSinkWithDefaultOptions()
+    {
             return new BackgroundWorkerSink(_logger, 10000, false);
         }
 
-        static LogEvent CreateEvent()
-        {
+    static LogEvent CreateEvent()
+    {
             return new LogEvent(DateTimeOffset.MaxValue, LogEventLevel.Error, null,
                 new MessageTemplate("amessage", Enumerable.Empty<MessageTemplateToken>()),
                 Enumerable.Empty<LogEventProperty>());
         }
-    }
 }

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkSpec.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Serilog.Core;
 using Serilog.Events;
@@ -19,226 +18,220 @@ public class BackgroundWorkerSinkSpec
 
     public BackgroundWorkerSinkSpec()
     {
-            _innerSink = new MemorySink();
-            _logger = new LoggerConfiguration().WriteTo.Sink(_innerSink).CreateLogger();
-        }
+        _innerSink = new MemorySink();
+        _logger = new LoggerConfiguration().WriteTo.Sink(_innerSink).CreateLogger();
+    }
 
     [Fact]
     public void WhenCtorWithNullSink_ThenThrows()
     {
-            Assert.Throws<ArgumentNullException>(() => new BackgroundWorkerSink(null, 10000, false, null));
-        }
+        Assert.Throws<ArgumentNullException>(() => new BackgroundWorkerSink(null!, 10000, false, null));
+    }
 
     [Fact]
     public async Task WhenEmitSingle_ThenRelaysToInnerSink()
     {
-            using (var sink = this.CreateSinkWithDefaultOptions())
-            {
-                var logEvent = CreateEvent();
+        using var sink = CreateSinkWithDefaultOptions();
+        var logEvent = CreateEvent();
 
-                sink.Emit(logEvent);
+        sink.Emit(logEvent);
 
-                await Task.Delay(TimeSpan.FromSeconds(3));
+        await Task.Delay(TimeSpan.FromSeconds(3));
 
-                Assert.Single(_innerSink.Events);
-            }
-        }
+        Assert.Single(_innerSink.Events);
+    }
 
     [Fact]
     public async Task WhenInnerEmitThrows_ThenContinuesRelaysToInnerSink()
     {
-            using (var sink = this.CreateSinkWithDefaultOptions())
-            {
-                _innerSink.ThrowAfterCollecting = true;
+        using var sink = CreateSinkWithDefaultOptions();
+        _innerSink.ThrowAfterCollecting = true;
 
-                var events = new List<LogEvent>
-                {
-                    CreateEvent(),
-                    CreateEvent(),
-                    CreateEvent()
-                };
-                events.ForEach(e => sink.Emit(e));
+        var events = new List<LogEvent>
+        {
+            CreateEvent(),
+            CreateEvent(),
+            CreateEvent()
+        };
+        events.ForEach(e => sink.Emit(e));
 
-                await Task.Delay(TimeSpan.FromSeconds(3));
+        await Task.Delay(TimeSpan.FromSeconds(3));
 
-                Assert.Equal(3, _innerSink.Events.Count);
-            }
-        }
+        Assert.Equal(3, _innerSink.Events.Count);
+    }
 
     [Fact]
     public async Task WhenEmitMultipleTimes_ThenRelaysToInnerSink()
     {
-            using (var sink = this.CreateSinkWithDefaultOptions())
-            {
-                var events = new List<LogEvent>
-                {
-                    CreateEvent(),
-                    CreateEvent(),
-                    CreateEvent()
-                };
-                events.ForEach(e => { sink.Emit(e); });
+        using var sink = CreateSinkWithDefaultOptions();
+        var events = new List<LogEvent>
+        {
+            CreateEvent(),
+            CreateEvent(),
+            CreateEvent()
+        };
+        events.ForEach(e => { sink.Emit(e); });
 
-                await Task.Delay(TimeSpan.FromSeconds(3));
+        await Task.Delay(TimeSpan.FromSeconds(3));
 
-                Assert.Equal(3, _innerSink.Events.Count);
-            }
-        }
+        Assert.Equal(3, _innerSink.Events.Count);
+    }
 
     [Fact]
     public async Task GivenDefaultConfig_WhenRequestsExceedCapacity_DoesNotBlock()
     {
-            var batchTiming = Stopwatch.StartNew();
-            using (var sink = new BackgroundWorkerSink(_logger, 1, blockWhenFull: false /*default*/))
+        var batchTiming = Stopwatch.StartNew();
+        using (var sink = new BackgroundWorkerSink(_logger, 1, false, null))
+        {
+            // Cause a delay when emitting to the inner sink, allowing us to easily fill the queue to capacity
+            // while the first event is being propagated
+            var acceptInterval = TimeSpan.FromMilliseconds(500);
+            _innerSink.DelayEmit = acceptInterval;
+            var tenSecondsWorth = 10_000 / acceptInterval.TotalMilliseconds + 1;
+            for (int i = 0; i < tenSecondsWorth; i++)
             {
-                // Cause a delay when emitting to the inner sink, allowing us to easily fill the queue to capacity
-                // while the first event is being propagated
-                var acceptInterval = TimeSpan.FromMilliseconds(500);
-                _innerSink.DelayEmit = acceptInterval;
-                var tenSecondsWorth = 10_000 / acceptInterval.TotalMilliseconds + 1;
-                for (int i = 0; i < tenSecondsWorth; i++)
-                {
-                    var emissionTiming = Stopwatch.StartNew();
-                    sink.Emit(CreateEvent());
-                    emissionTiming.Stop();
+                var emissionTiming = Stopwatch.StartNew();
+                sink.Emit(CreateEvent());
+                emissionTiming.Stop();
 
-                    // Should not block the caller when the queue is full
-                    Assert.InRange(emissionTiming.ElapsedMilliseconds, 0, 200);
-                }
-
-                // Allow at least one to propagate
-                await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
-                Assert.NotEqual(0, ((IAsyncLogEventSinkInspector)sink).DroppedMessagesCount);
+                // Should not block the caller when the queue is full
+                Assert.InRange(emissionTiming.ElapsedMilliseconds, 0, 200);
             }
-            // Sanity check the overall timing
-            batchTiming.Stop();
-            // Need to add a significant fudge factor as AppVeyor build can result in `await` taking quite some time
-            Assert.InRange(batchTiming.ElapsedMilliseconds, 950, 2050);
+
+            // Allow at least one to propagate
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            Assert.NotEqual(0, ((IAsyncLogEventSinkInspector)sink).DroppedMessagesCount);
         }
+
+        // Sanity check the overall timing
+        batchTiming.Stop();
+        // Need to add a significant fudge factor as AppVeyor build can result in `await` taking quite some time
+        Assert.InRange(batchTiming.ElapsedMilliseconds, 950, 2050);
+    }
 
     [Fact]
     public async Task GivenDefaultConfig_WhenRequestsExceedCapacity_ThenDropsEventsAndRecovers()
     {
-            using (var sink = new BackgroundWorkerSink(_logger, 1, blockWhenFull: false /*default*/))
-            {
-                var acceptInterval = TimeSpan.FromMilliseconds(200);
-                _innerSink.DelayEmit = acceptInterval;
+        using var sink = new BackgroundWorkerSink(_logger, 1, false, null);
+        var acceptInterval = TimeSpan.FromMilliseconds(200);
+        _innerSink.DelayEmit = acceptInterval;
 
-                for (int i = 0; i < 2; i++)
-                {
-                    sink.Emit(CreateEvent());
-                    sink.Emit(CreateEvent());
-                    await Task.Delay(acceptInterval);
-                    sink.Emit(CreateEvent());
-                }
-                // Wait for the buffer and propagation to complete
-                await Task.Delay(TimeSpan.FromSeconds(1));
-                // Now verify things are back to normal; emit an event...
-                var finalEvent = CreateEvent();
-                sink.Emit(finalEvent);
-                // ... give adequate time for it to be guaranteed to have percolated through
-                await Task.Delay(TimeSpan.FromSeconds(1));
-
-                // At least one of the preceding events should not have made it through
-                var propagatedExcludingFinal =
-                    from e in _innerSink.Events
-                    where !Object.ReferenceEquals(finalEvent, e)
-                    select e;
-                Assert.InRange(2, 2 * 3 / 2 - 1, propagatedExcludingFinal.Count());
-                // Final event should have made it through
-                Assert.Contains(_innerSink.Events, x => Object.ReferenceEquals(finalEvent, x));
-                Assert.NotEqual(0, ((IAsyncLogEventSinkInspector)sink).DroppedMessagesCount);
-            }
+        for (int i = 0; i < 2; i++)
+        {
+            sink.Emit(CreateEvent());
+            sink.Emit(CreateEvent());
+            await Task.Delay(acceptInterval);
+            sink.Emit(CreateEvent());
         }
+
+        // Wait for the buffer and propagation to complete
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        // Now verify things are back to normal; emit an event...
+        var finalEvent = CreateEvent();
+        sink.Emit(finalEvent);
+        // ... give adequate time for it to be guaranteed to have percolated through
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        // At least one of the preceding events should not have made it through
+        var propagatedExcludingFinal =
+            from e in _innerSink.Events
+            where !Object.ReferenceEquals(finalEvent, e)
+            select e;
+        Assert.InRange(2, 2 * 3 / 2 - 1, propagatedExcludingFinal.Count());
+        // Final event should have made it through
+        Assert.Contains(_innerSink.Events, x => ReferenceEquals(finalEvent, x));
+        Assert.NotEqual(0, ((IAsyncLogEventSinkInspector)sink).DroppedMessagesCount);
+    }
 
     [Fact]
     public async Task GivenConfiguredToBlock_WhenQueueFilled_ThenBlocks()
     {
-            using (var sink = new BackgroundWorkerSink(_logger, 1, blockWhenFull: true))
+        using var sink = new BackgroundWorkerSink(_logger, 1, true, null);
+        // Cause a delay when emitting to the inner sink, allowing us to fill the queue to capacity
+        // after the first event is popped
+        _innerSink.DelayEmit = TimeSpan.FromMilliseconds(300);
+
+        var events = new List<LogEvent>
+        {
+            CreateEvent(),
+            CreateEvent(),
+            CreateEvent()
+        };
+
+        int i = 0;
+        events.ForEach(e =>
+        {
+            var sw = Stopwatch.StartNew();
+            sink.Emit(e);
+            sw.Stop();
+
+            // Emit should return immediately the first time, since the queue is not yet full. On
+            // subsequent calls, the queue should be full, so we should be blocked
+            if (i > 0)
             {
-                // Cause a delay when emmitting to the inner sink, allowing us to fill the queue to capacity
-                // after the first event is popped
-                _innerSink.DelayEmit = TimeSpan.FromMilliseconds(300);
-
-                var events = new List<LogEvent>
-                {
-                    CreateEvent(),
-                    CreateEvent(),
-                    CreateEvent()
-                };
-
-                int i = 0;
-                events.ForEach(e =>
-                {
-                    var sw = Stopwatch.StartNew();
-                    sink.Emit(e);
-                    sw.Stop();
-
-                    // Emit should return immediately the first time, since the queue is not yet full. On
-                    // subsequent calls, the queue should be full, so we should be blocked
-                    if (i > 0)
-                    {
-                        Assert.True(sw.ElapsedMilliseconds > 200, "Should block the caller when the queue is full");
-                    }
-                });
-
-                await Task.Delay(TimeSpan.FromSeconds(2));
-
-                // No events should be dropped
-                Assert.Equal(3, _innerSink.Events.Count);
-                Assert.Equal(0, ((IAsyncLogEventSinkInspector)sink).DroppedMessagesCount);
+                Assert.True(sw.ElapsedMilliseconds > 200, "Should block the caller when the queue is full");
             }
-        }
+        });
+
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        // No events should be dropped
+        Assert.Equal(3, _innerSink.Events.Count);
+        Assert.Equal(0, ((IAsyncLogEventSinkInspector)sink).DroppedMessagesCount);
+    }
 
     [Fact]
     public void MonitorParameterAffordsSinkInspectorSuitableForHealthChecking()
     {
-            var collector = new MemorySink { DelayEmit = TimeSpan.FromSeconds(2) };
-            // 2 spaces in queue; 1 would make the second log entry eligible for dropping if consumer does not activate instantaneously
-            var bufferSize = 2;
-            var monitor = new DummyMonitor();
-            using (var logger = new LoggerConfiguration()
-                .WriteTo.Async(w => w.Sink(collector), bufferSize: 2, monitor: monitor)
-                .CreateLogger())
-            {
-                // Construction of BackgroundWorkerSink triggers StartMonitoring
-                var inspector = monitor.Inspector;
-                Assert.Equal(bufferSize, inspector.BufferSize);
-                Assert.Equal(0, inspector.Count);
-                Assert.Equal(0, inspector.DroppedMessagesCount);
-                logger.Information("Something to freeze the processing for 2s");
-                // Can be taken from queue either instantanously or be awaiting consumer to take
-                Assert.InRange(inspector.Count, 0, 1);
-                Assert.Equal(0, inspector.DroppedMessagesCount);
-                logger.Information("Something that will sit in the queue");
-                Assert.InRange(inspector.Count, 1, 2);
-                logger.Information("Something that will probably also sit in the queue (but could get dropped if first message has still not been picked up)");
-                Assert.InRange(inspector.Count, 1, 2);
-                logger.Information("Something that will get dropped unless we get preempted for 2s during our execution");
-                const string droppedMessage = "Something that will definitely get dropped";
-                logger.Information(droppedMessage);
-                Assert.InRange(inspector.Count, 1, 2);
-                // Unless we are put to sleep for a Rip Van Winkle period, either:
-                // a) the BackgroundWorker will be emitting the item [and incurring the 2s delay we established], leaving a single item in the buffer
-                // or b) neither will have been picked out of the buffer yet.
-                Assert.InRange(inspector.Count, 1, 2);
-                Assert.Equal(bufferSize, inspector.BufferSize);
-                Assert.DoesNotContain(collector.Events, x => x.MessageTemplate.Text == droppedMessage);
-                // Because messages wait 2 seconds, the only real way to get one into the buffer is with a debugger breakpoint or a sleep
-                Assert.InRange(collector.Events.Count, 0, 3);
-            }
-            // Dispose should trigger a StopMonitoring call
-            Assert.Null(monitor.Inspector);
+        var collector = new MemorySink { DelayEmit = TimeSpan.FromSeconds(2) };
+        // 2 spaces in queue; 1 would make the second log entry eligible for dropping if consumer does not activate instantaneously
+        var bufferSize = 2;
+        var monitor = new DummyMonitor();
+        using (var logger = new LoggerConfiguration()
+                   .WriteTo.Async(w => w.Sink(collector), bufferSize: 2, monitor: monitor)
+                   .CreateLogger())
+        {
+            // Construction of BackgroundWorkerSink triggers StartMonitoring
+            var inspector = monitor.Inspector;
+            Assert.Equal(bufferSize, inspector.BufferSize);
+            Assert.Equal(0, inspector.Count);
+            Assert.Equal(0, inspector.DroppedMessagesCount);
+            logger.Information("Something to freeze the processing for 2s");
+            // Can be taken from queue either instantanously or be awaiting consumer to take
+            Assert.InRange(inspector.Count, 0, 1);
+            Assert.Equal(0, inspector.DroppedMessagesCount);
+            logger.Information("Something that will sit in the queue");
+            Assert.InRange(inspector.Count, 1, 2);
+            logger.Information(
+                "Something that will probably also sit in the queue (but could get dropped if first message has still not been picked up)");
+            Assert.InRange(inspector.Count, 1, 2);
+            logger.Information("Something that will get dropped unless we get preempted for 2s during our execution");
+            const string droppedMessage = "Something that will definitely get dropped";
+            logger.Information(droppedMessage);
+            Assert.InRange(inspector.Count, 1, 2);
+            // Unless we are put to sleep for a Rip Van Winkle period, either:
+            // a) the BackgroundWorker will be emitting the item [and incurring the 2s delay we established], leaving a single item in the buffer
+            // or b) neither will have been picked out of the buffer yet.
+            Assert.InRange(inspector.Count, 1, 2);
+            Assert.Equal(bufferSize, inspector.BufferSize);
+            Assert.DoesNotContain(collector.Events, x => x.MessageTemplate.Text == droppedMessage);
+            // Because messages wait 2 seconds, the only real way to get one into the buffer is with a debugger breakpoint or a sleep
+            Assert.InRange(collector.Events.Count, 0, 3);
         }
+
+        // Dispose should trigger a StopMonitoring call
+        Assert.Null(monitor.Inspector);
+    }
 
     BackgroundWorkerSink CreateSinkWithDefaultOptions()
     {
-            return new BackgroundWorkerSink(_logger, 10000, false);
-        }
+        return new BackgroundWorkerSink(_logger, 10000, false, null);
+    }
 
     static LogEvent CreateEvent()
     {
-            return new LogEvent(DateTimeOffset.MaxValue, LogEventLevel.Error, null,
-                new MessageTemplate("amessage", Enumerable.Empty<MessageTemplateToken>()),
-                Enumerable.Empty<LogEventProperty>());
-        }
+        return new LogEvent(DateTimeOffset.MaxValue, LogEventLevel.Error, null,
+            new MessageTemplate("amessage", Enumerable.Empty<MessageTemplateToken>()),
+            Enumerable.Empty<LogEventProperty>());
+    }
 }

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkTests.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkTests.cs
@@ -8,46 +8,46 @@ public class BackgroundWorkerSinkTests
     [Fact]
     public void EventsArePassedToInnerSink()
     {
-            var collector = new MemorySink();
+        var collector = new MemorySink();
 
-            using (var log = new LoggerConfiguration()
-                .WriteTo.Async(w => w.Sink(collector))
-                .CreateLogger())
-            {
-                log.Information("Hello, async world!");
-                log.Information("Hello again!");
-            }
-
-            Assert.Equal(2, collector.Events.Count);
+        using (var log = new LoggerConfiguration()
+                   .WriteTo.Async(w => w.Sink(collector))
+                   .CreateLogger())
+        {
+            log.Information("Hello, async world!");
+            log.Information("Hello again!");
         }
+
+        Assert.Equal(2, collector.Events.Count);
+    }
 
     [Fact]
     public void DisposeCompletesWithoutWorkPerformed()
     {
-            var collector = new MemorySink();
+        var collector = new MemorySink();
 
-            using (new LoggerConfiguration()
-                .WriteTo.Async(w => w.Sink(collector))
-                .CreateLogger())
-            {
-            }
-
-            Assert.Empty(collector.Events);
+        using (new LoggerConfiguration()
+                   .WriteTo.Async(w => w.Sink(collector))
+                   .CreateLogger())
+        {
         }
+
+        Assert.Empty(collector.Events);
+    }
 
     [Fact]
     public void CtorAndDisposeInformMonitor()
     {
-            var collector = new MemorySink();
-            var monitor = new DummyMonitor();
+        var collector = new MemorySink();
+        var monitor = new DummyMonitor();
 
-            using (new LoggerConfiguration()
-                .WriteTo.Async(w => w.Sink(collector), monitor: monitor)
-                .CreateLogger())
-            {
-                Assert.NotNull(monitor.Inspector);
-            }
-
-            Assert.Null(monitor.Inspector);
+        using (new LoggerConfiguration()
+                   .WriteTo.Async(w => w.Sink(collector), monitor: monitor)
+                   .CreateLogger())
+        {
+            Assert.NotNull(monitor.Inspector);
         }
+
+        Assert.Null(monitor.Inspector);
+    }
 }

--- a/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkTests.cs
+++ b/test/Serilog.Sinks.Async.Tests/BackgroundWorkerSinkTests.cs
@@ -1,13 +1,13 @@
 ﻿using Serilog.Sinks.Async.Tests.Support;
 using Xunit;
 
-namespace Serilog.Sinks.Async.Tests
+namespace Serilog.Sinks.Async.Tests;
+
+public class BackgroundWorkerSinkTests
 {
-    public class BackgroundWorkerSinkTests
+    [Fact]
+    public void EventsArePassedToInnerSink()
     {
-        [Fact]
-        public void EventsArePassedToInnerSink()
-        {
             var collector = new MemorySink();
 
             using (var log = new LoggerConfiguration()
@@ -21,9 +21,9 @@ namespace Serilog.Sinks.Async.Tests
             Assert.Equal(2, collector.Events.Count);
         }
 
-        [Fact]
-        public void DisposeCompletesWithoutWorkPerformed()
-        {
+    [Fact]
+    public void DisposeCompletesWithoutWorkPerformed()
+    {
             var collector = new MemorySink();
 
             using (new LoggerConfiguration()
@@ -35,9 +35,9 @@ namespace Serilog.Sinks.Async.Tests
             Assert.Empty(collector.Events);
         }
 
-        [Fact]
-        public void CtorAndDisposeInformMonitor()
-        {
+    [Fact]
+    public void CtorAndDisposeInformMonitor()
+    {
             var collector = new MemorySink();
             var monitor = new DummyMonitor();
 
@@ -50,5 +50,4 @@ namespace Serilog.Sinks.Async.Tests
 
             Assert.Null(monitor.Inspector);
         }
-    }
 }

--- a/test/Serilog.Sinks.Async.Tests/Serilog.Sinks.Async.Tests.csproj
+++ b/test/Serilog.Sinks.Async.Tests/Serilog.Sinks.Async.Tests.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-    <AssemblyName>Serilog.Sinks.Async.Tests</AssemblyName>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>Serilog.Sinks.Async.Tests</PackageId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,10 +18,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.Sinks.Async.Tests/Serilog.Sinks.Async.Tests.csproj
+++ b/test/Serilog.Sinks.Async.Tests/Serilog.Sinks.Async.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net48</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net6.0;net8.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/test/Serilog.Sinks.Async.Tests/Serilog.Sinks.Async.Tests.csproj
+++ b/test/Serilog.Sinks.Async.Tests/Serilog.Sinks.Async.Tests.csproj
@@ -12,12 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.8.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.Sinks.Async.Tests/Support/DummyMonitor.cs
+++ b/test/Serilog.Sinks.Async.Tests/Support/DummyMonitor.cs
@@ -1,14 +1,13 @@
-﻿namespace Serilog.Sinks.Async.Tests.Support
+﻿namespace Serilog.Sinks.Async.Tests.Support;
+
+class DummyMonitor : IAsyncLogEventSinkMonitor
 {
-    class DummyMonitor : IAsyncLogEventSinkMonitor
-    {
-        IAsyncLogEventSinkInspector inspector;
-        public IAsyncLogEventSinkInspector Inspector => inspector;
+    IAsyncLogEventSinkInspector inspector;
+    public IAsyncLogEventSinkInspector Inspector => inspector;
 
-        void IAsyncLogEventSinkMonitor.StartMonitoring(IAsyncLogEventSinkInspector inspector) =>
-            this.inspector = inspector;
+    void IAsyncLogEventSinkMonitor.StartMonitoring(IAsyncLogEventSinkInspector inspector) =>
+        this.inspector = inspector;
 
-        void IAsyncLogEventSinkMonitor.StopMonitoring(IAsyncLogEventSinkInspector inspector) =>
-            System.Threading.Interlocked.CompareExchange(ref this.inspector, null, inspector);
-    }
+    void IAsyncLogEventSinkMonitor.StopMonitoring(IAsyncLogEventSinkInspector inspector) =>
+        System.Threading.Interlocked.CompareExchange(ref this.inspector, null, inspector);
 }

--- a/test/Serilog.Sinks.Async.Tests/Support/Loop.cs
+++ b/test/Serilog.Sinks.Async.Tests/Support/Loop.cs
@@ -2,128 +2,127 @@
 using System.Diagnostics;
 using System.Threading.Tasks;
 
-namespace Serilog.Sinks.Async.Tests.Support
+namespace Serilog.Sinks.Async.Tests.Support;
+
+public static class Loop
 {
-    public static class Loop
+    /// <summary>
+    ///     Repeats the specified <see cref="action" />, until the specified <see cref="until" /> returns true,
+    ///     With a delay between retries of <see cref="retryInterval" />, or until the <see cref="timeout " /> is exceeded.
+    /// </summary>
+    /// <typeparam name="TResult"> The type of the result of the <see cref="action" /> </typeparam>
+    /// <param name="action"> The action to perform </param>
+    /// <param name="until"> The predicate which determines whether the action has completed </param>
+    /// <param name="retryInterval"> The delay between retries </param>
+    /// <param name="timeout"> The time after which the retries are cancelled </param>
+    /// <returns> </returns>
+    public static RetryResult<TResult> Retry<TResult>(this Func<TResult> action, Predicate<TResult> until,
+        TimeSpan retryInterval, TimeSpan timeout)
     {
-        /// <summary>
-        ///     Repeats the specified <see cref="action" />, until the specified <see cref="until" /> returns true,
-        ///     With a delay between retries of <see cref="retryInterval" />, or until the <see cref="timeout " /> is exceeded.
-        /// </summary>
-        /// <typeparam name="TResult"> The type of the result of the <see cref="action" /> </typeparam>
-        /// <param name="action"> The action to perform </param>
-        /// <param name="until"> The predicate which determines whether the action has completed </param>
-        /// <param name="retryInterval"> The delay between retries </param>
-        /// <param name="timeout"> The time after which the retries are cancelled </param>
-        /// <returns> </returns>
-        public static RetryResult<TResult> Retry<TResult>(this Func<TResult> action, Predicate<TResult> until,
-            TimeSpan retryInterval, TimeSpan timeout)
+        var retries = 0;
+        TResult result;
+        var stopwatch = Stopwatch.StartNew();
+        do
         {
-            var retries = 0;
-            TResult result;
-            var stopwatch = Stopwatch.StartNew();
-            do
+            retries++;
+            result = action();
+
+            if (until(result))
             {
-                retries++;
-                result = action();
-
-                if (until(result))
-                {
-                    return new RetryResult<TResult>(result, retries, stopwatch.Elapsed);
-                }
-
-                Task.Delay((int)retryInterval.TotalMilliseconds).Wait();
-            } while (stopwatch.Elapsed < timeout);
-
-            return new RetryResult<TResult>(result, retries, stopwatch.Elapsed);
-        }
-
-        /// <summary>
-        ///     Repeats the specified <see cref="action" />, until the specified <see cref="timeout" />,
-        ///     With a delay between retries of <see cref="retryInterval" />
-        /// </summary>
-        /// <typeparam name="TResult"> The type of the result of the <see cref="action" /> </typeparam>
-        /// <param name="action"> The action to perform </param>
-        /// <param name="retryInterval"> The delay between retries </param>
-        /// <param name="timeout"> The time after which the retries are cancelled </param>
-        /// <returns> </returns>
-        public static RetryResult<TResult> RetryUntilTimesout<TResult>(this Func<TResult> action,
-            TimeSpan retryInterval, TimeSpan timeout)
-        {
-            var retries = 0;
-            TResult result;
-            var stopwatch = Stopwatch.StartNew();
-            do
-            {
-                retries++;
-                result = action();
-
-                Task.Delay((int)retryInterval.TotalMilliseconds).Wait();
-            } while (stopwatch.Elapsed < timeout);
-
-            return new RetryResult<TResult>(result, retries, stopwatch.Elapsed);
-        }
-
-        /// <summary>
-        ///     Repeats the specified <see cref="action" /> the specified number of times
-        /// </summary>
-        public static void For(Action action, int times)
-        {
-            if (times > 0)
-            {
-                for (var counter = 0; counter < times; counter++)
-                {
-                    action();
-                }
+                return new RetryResult<TResult>(result, retries, stopwatch.Elapsed);
             }
-        }
 
-        /// <summary>
-        ///     Repeats the specified <see cref="Action{Int32}" /> the specified number of times, from 0 to <see cref="to" />
-        /// </summary>
-        public static void For(Action<int> action, int to)
-        {
-            if (to > 0)
-            {
-                for (var counter = 0; counter < to; counter++)
-                {
-                    action(counter);
-                }
-            }
-        }
+            Task.Delay((int)retryInterval.TotalMilliseconds).Wait();
+        } while (stopwatch.Elapsed < timeout);
 
-        /// <summary>
-        ///     Repeats the specified <see cref="Action{Int32}" /> the specified number of times, from <see cref="from" /> to
-        ///     <see cref="to" />
-        /// </summary>
-        public static void For(Action<int> action, int from, int to)
+        return new RetryResult<TResult>(result, retries, stopwatch.Elapsed);
+    }
+
+    /// <summary>
+    ///     Repeats the specified <see cref="action" />, until the specified <see cref="timeout" />,
+    ///     With a delay between retries of <see cref="retryInterval" />
+    /// </summary>
+    /// <typeparam name="TResult"> The type of the result of the <see cref="action" /> </typeparam>
+    /// <param name="action"> The action to perform </param>
+    /// <param name="retryInterval"> The delay between retries </param>
+    /// <param name="timeout"> The time after which the retries are cancelled </param>
+    /// <returns> </returns>
+    public static RetryResult<TResult> RetryUntilTimesout<TResult>(this Func<TResult> action,
+        TimeSpan retryInterval, TimeSpan timeout)
+    {
+        var retries = 0;
+        TResult result;
+        var stopwatch = Stopwatch.StartNew();
+        do
         {
-            if (to > 0
-                && from >= 0
-                && from <= to)
+            retries++;
+            result = action();
+
+            Task.Delay((int)retryInterval.TotalMilliseconds).Wait();
+        } while (stopwatch.Elapsed < timeout);
+
+        return new RetryResult<TResult>(result, retries, stopwatch.Elapsed);
+    }
+
+    /// <summary>
+    ///     Repeats the specified <see cref="action" /> the specified number of times
+    /// </summary>
+    public static void For(Action action, int times)
+    {
+        if (times > 0)
+        {
+            for (var counter = 0; counter < times; counter++)
             {
-                var maxCount = (from > 0) ? (to + 1) : to;
-                for (var counter = from; counter < maxCount; counter++)
-                {
-                    action(counter);
-                }
+                action();
             }
         }
     }
 
-    public class RetryResult<TResult>
+    /// <summary>
+    ///     Repeats the specified <see cref="Action{Int32}" /> the specified number of times, from 0 to <see cref="to" />
+    /// </summary>
+    public static void For(Action<int> action, int to)
     {
-        public RetryResult(TResult result, int retries, TimeSpan elapsed)
+        if (to > 0)
         {
-            Result = result;
-            Retries = retries;
-            Elapsed = elapsed;
+            for (var counter = 0; counter < to; counter++)
+            {
+                action(counter);
+            }
         }
-
-        public int Retries { get; private set; }
-
-        public TimeSpan Elapsed { get; private set; }
-
-        public TResult Result { get; private set; }
     }
+
+    /// <summary>
+    ///     Repeats the specified <see cref="Action{Int32}" /> the specified number of times, from <see cref="from" /> to
+    ///     <see cref="to" />
+    /// </summary>
+    public static void For(Action<int> action, int from, int to)
+    {
+        if (to > 0
+            && from >= 0
+            && from <= to)
+        {
+            var maxCount = (from > 0) ? (to + 1) : to;
+            for (var counter = from; counter < maxCount; counter++)
+            {
+                action(counter);
+            }
+        }
+    }
+}
+
+public class RetryResult<TResult>
+{
+    public RetryResult(TResult result, int retries, TimeSpan elapsed)
+    {
+        Result = result;
+        Retries = retries;
+        Elapsed = elapsed;
+    }
+
+    public int Retries { get; private set; }
+
+    public TimeSpan Elapsed { get; private set; }
+
+    public TResult Result { get; private set; }
 }

--- a/test/Serilog.Sinks.Async.Tests/Support/MemorySink.cs
+++ b/test/Serilog.Sinks.Async.Tests/Support/MemorySink.cs
@@ -4,23 +4,22 @@ using System.Collections.Concurrent;
 using System;
 using System.Threading.Tasks;
 
-namespace Serilog.Sinks.Async.Tests.Support
+namespace Serilog.Sinks.Async.Tests.Support;
+
+public class MemorySink : ILogEventSink
 {
-    public class MemorySink : ILogEventSink
+    public ConcurrentBag<LogEvent> Events { get; } = new ConcurrentBag<LogEvent>();
+    public bool ThrowAfterCollecting { get; set; }
+    public TimeSpan? DelayEmit { get; set; }
+
+    public void Emit(LogEvent logEvent)
     {
-        public ConcurrentBag<LogEvent> Events { get; } = new ConcurrentBag<LogEvent>();
-        public bool ThrowAfterCollecting { get; set; }
-        public TimeSpan? DelayEmit { get; set; }
+        if (DelayEmit.HasValue)
+            Task.Delay(DelayEmit.Value).Wait();
 
-        public void Emit(LogEvent logEvent)
-        {
-            if (DelayEmit.HasValue)
-                Task.Delay(DelayEmit.Value).Wait();
+        Events.Add(logEvent);
 
-            Events.Add(logEvent);
-
-            if (ThrowAfterCollecting)
-                throw new Exception($"Exception requested through {nameof(ThrowAfterCollecting)}.");
-        }
+        if (ThrowAfterCollecting)
+            throw new Exception($"Exception requested through {nameof(ThrowAfterCollecting)}.");
     }
 }


### PR DESCRIPTION
Needs to be viewed with whitespace changes hidden.

 * Update to Serilog 4 - drops TFMs earlier than netstandard2.0
 * Update CSPROJ to modern defaults
 * Update to C# 12, enable strict null checks
 * Rationalize the three very similar configuration methods (`monitor` argument is now last) - binary breaking change, and will be a source breaking change for anyone using queue monitoring
 * VS2022 worker image, pull pwsh build script from Serilog.Sinks.File


